### PR TITLE
Capture total times by each locator

### DIFF
--- a/crates/pet-conda/src/lib.rs
+++ b/crates/pet-conda/src/lib.rs
@@ -146,6 +146,9 @@ impl Conda {
 }
 
 impl Locator for Conda {
+    fn get_name(&self) -> &'static str {
+        "Conda"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![PythonEnvironmentCategory::Conda]
     }

--- a/crates/pet-core/src/lib.rs
+++ b/crates/pet-core/src/lib.rs
@@ -34,6 +34,8 @@ pub struct Configuration {
 }
 
 pub trait Locator: Send + Sync {
+    /// Returns the name of the locator.
+    fn get_name(&self) -> &'static str;
     fn configure(&self, _config: &Configuration) {
         //
     }

--- a/crates/pet-homebrew/src/lib.rs
+++ b/crates/pet-homebrew/src/lib.rs
@@ -98,6 +98,9 @@ fn from(env: &PythonEnv) -> Option<PythonEnvironment> {
 }
 
 impl Locator for Homebrew {
+    fn get_name(&self) -> &'static str {
+        "Homebrew"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![PythonEnvironmentCategory::Homebrew]
     }

--- a/crates/pet-linux-global-python/src/lib.rs
+++ b/crates/pet-linux-global-python/src/lib.rs
@@ -26,6 +26,9 @@ impl Default for LinuxGlobalPython {
     }
 }
 impl Locator for LinuxGlobalPython {
+    fn get_name(&self) -> &'static str {
+        "LinuxGlobalPython"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![PythonEnvironmentCategory::LinuxGlobal]
     }

--- a/crates/pet-mac-commandlinetools/src/lib.rs
+++ b/crates/pet-mac-commandlinetools/src/lib.rs
@@ -28,6 +28,9 @@ impl Default for MacCmdLineTools {
     }
 }
 impl Locator for MacCmdLineTools {
+    fn get_name(&self) -> &'static str {
+        "MacCmdLineTools"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![PythonEnvironmentCategory::MacCommandLineTools]
     }

--- a/crates/pet-mac-python-org/src/lib.rs
+++ b/crates/pet-mac-python-org/src/lib.rs
@@ -27,6 +27,9 @@ impl Default for MacPythonOrg {
     }
 }
 impl Locator for MacPythonOrg {
+    fn get_name(&self) -> &'static str {
+        "MacPythonOrg"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![PythonEnvironmentCategory::MacPythonOrg]
     }

--- a/crates/pet-mac-xcode/src/lib.rs
+++ b/crates/pet-mac-xcode/src/lib.rs
@@ -25,6 +25,9 @@ impl Default for MacXCode {
     }
 }
 impl Locator for MacXCode {
+    fn get_name(&self) -> &'static str {
+        "MacXCode"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![PythonEnvironmentCategory::MacCommandLineTools]
     }

--- a/crates/pet-pipenv/src/lib.rs
+++ b/crates/pet-pipenv/src/lib.rs
@@ -71,6 +71,9 @@ impl PipEnv {
     }
 }
 impl Locator for PipEnv {
+    fn get_name(&self) -> &'static str {
+        "PipEnv"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![PythonEnvironmentCategory::Pipenv]
     }

--- a/crates/pet-poetry/src/lib.rs
+++ b/crates/pet-poetry/src/lib.rs
@@ -134,6 +134,9 @@ impl Poetry {
 }
 
 impl Locator for Poetry {
+    fn get_name(&self) -> &'static str {
+        "Poetry"
+    }
     fn configure(&self, config: &Configuration) {
         if let Some(search_paths) = &config.search_paths {
             if !search_paths.is_empty() {

--- a/crates/pet-pyenv/src/lib.rs
+++ b/crates/pet-pyenv/src/lib.rs
@@ -48,6 +48,9 @@ impl PyEnv {
 }
 
 impl Locator for PyEnv {
+    fn get_name(&self) -> &'static str {
+        "PyEnv"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![
             PythonEnvironmentCategory::Pyenv,

--- a/crates/pet-venv/src/lib.rs
+++ b/crates/pet-venv/src/lib.rs
@@ -33,6 +33,9 @@ impl Default for Venv {
     }
 }
 impl Locator for Venv {
+    fn get_name(&self) -> &'static str {
+        "Venv"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![PythonEnvironmentCategory::Venv]
     }

--- a/crates/pet-virtualenv/src/lib.rs
+++ b/crates/pet-virtualenv/src/lib.rs
@@ -71,6 +71,9 @@ impl Default for VirtualEnv {
 }
 
 impl Locator for VirtualEnv {
+    fn get_name(&self) -> &'static str {
+        "VirtualEnv"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![PythonEnvironmentCategory::VirtualEnv]
     }

--- a/crates/pet-virtualenvwrapper/src/lib.rs
+++ b/crates/pet-virtualenvwrapper/src/lib.rs
@@ -29,6 +29,9 @@ impl VirtualEnvWrapper {
 }
 
 impl Locator for VirtualEnvWrapper {
+    fn get_name(&self) -> &'static str {
+        "VirtualEnvWrapper"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![PythonEnvironmentCategory::VirtualEnvWrapper]
     }

--- a/crates/pet-windows-registry/src/lib.rs
+++ b/crates/pet-windows-registry/src/lib.rs
@@ -62,6 +62,9 @@ impl WindowsRegistry {
 }
 
 impl Locator for WindowsRegistry {
+    fn get_name(&self) -> &'static str {
+        "WindowsRegistry"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![PythonEnvironmentCategory::WindowsRegistry]
     }

--- a/crates/pet-windows-store/src/lib.rs
+++ b/crates/pet-windows-store/src/lib.rs
@@ -61,6 +61,9 @@ impl WindowsStore {
 }
 
 impl Locator for WindowsStore {
+    fn get_name(&self) -> &'static str {
+        "WindowsStore"
+    }
     fn supported_categories(&self) -> Vec<PythonEnvironmentCategory> {
         vec![PythonEnvironmentCategory::WindowsStore]
     }

--- a/crates/pet/src/lib.rs
+++ b/crates/pet/src/lib.rs
@@ -42,24 +42,24 @@ pub fn find_and_report_envs_stdio(print_list: bool, print_summary: bool, verbose
         println!("Breakdown by each locator:");
         println!("--------------------------");
         for locator in summary.find_locators_times.iter() {
-            println!("Locator {} took {:?}", locator.0, locator.1);
+            println!("{:<20} : {:?}", locator.0, locator.1);
         }
         println!();
 
-        println!("Breakdown:");
-        println!("----------");
+        println!("Breakdown for finding Environments:");
+        println!("-----------------------------------");
         println!(
-            "Environments found using locators in {:?}",
-            summary.find_locators_time
+            "{:<20} : {:?}",
+            "Using locators", summary.find_locators_time
         );
-        println!("Environments in PATH found in {:?}", summary.find_path_time);
+        println!("{:<20} : {:?}", "PATH Variable", summary.find_path_time);
         println!(
-            "Environments in global virtual env paths found in {:?}",
-            summary.find_global_virtual_envs_time
+            "{:<20} : {:?}",
+            "Global virtual envs", summary.find_global_virtual_envs_time
         );
         println!(
-            "Environments in custom search paths found in {:?}",
-            summary.find_search_paths_time
+            "{:<20} : {:?}",
+            "Custom search paths", summary.find_search_paths_time
         );
         println!();
         let summary = stdio_reporter.get_summary();

--- a/crates/pet/src/lib.rs
+++ b/crates/pet/src/lib.rs
@@ -34,9 +34,32 @@ pub fn find_and_report_envs_stdio(print_list: bool, print_summary: bool, verbose
         locator.configure(&config);
     }
 
-    find_and_report_envs(&reporter, config, &locators, conda_locator);
+    let summary = find_and_report_envs(&reporter, config, &locators, conda_locator);
 
     if print_summary {
+        let summary = summary.lock().unwrap();
+        println!();
+        println!("Breakdown by each locator:");
+        for locator in summary.find_locators_times.iter() {
+            println!("Locator {} took {:?}", locator.0, locator.1);
+        }
+        println!();
+
+        println!("Breakdown:");
+        println!(
+            "Environments found using locators in {:?}",
+            summary.find_locators_time
+        );
+        println!("Environments in PATH found in {:?}", summary.find_path_time);
+        println!(
+            "Environments in global virtual env paths found in {:?}",
+            summary.find_global_virtual_envs_time
+        );
+        println!(
+            "Environments in custom search paths found in {:?}",
+            summary.find_search_paths_time
+        );
+        println!();
         let summary = stdio_reporter.get_summary();
         if !summary.managers.is_empty() {
             println!("Managers:");

--- a/crates/pet/src/lib.rs
+++ b/crates/pet/src/lib.rs
@@ -40,12 +40,14 @@ pub fn find_and_report_envs_stdio(print_list: bool, print_summary: bool, verbose
         let summary = summary.lock().unwrap();
         println!();
         println!("Breakdown by each locator:");
+        println!("--------------------------");
         for locator in summary.find_locators_times.iter() {
             println!("Locator {} took {:?}", locator.0, locator.1);
         }
         println!();
 
         println!("Breakdown:");
+        println!("----------");
         println!(
             "Environments found using locators in {:?}",
             summary.find_locators_time


### PR DESCRIPTION
Helps us with a breakdown
```
Breakdown by each locator:
--------------------------
VirtualEnvWrapper    : 697.167µs
MacXCode             : 538.458µs
Venv                 : 699.5µs
MacCmdLineTools      : 194.643458ms
VirtualEnv           : 665.459µs
MacPythonOrg         : 32.387083ms
Homebrew             : 81.388042ms
PyEnv                : 141.412542ms
Conda                : 250.8985ms
Poetry               : 948.042µs
PipEnv               : 625ns

Breakdown for finding Environments:
-----------------------------------
Using locators       : 251.063625ms
PATH Variable        : 214.762458ms
Global virtual envs  : 81.220291ms
Custom search paths  : 1.252041ms

Managers:
---------
Conda                : 6
Poetry               : 1
Pyenv                : 1

Environments (50):
------------------
Conda                : 27
Homebrew             : 4
MacCommandLineTools  : 1
MacPythonOrg         : 1
MacXCode             : 1
Pipenv               : 1
Pyenv                : 9
PyenvVirtualEnv      : 3
Venv                 : 1
VirtualEnvWrapper    : 2
```