### PR TITLE
Avoid spawning processes too many times

### DIFF
--- a/crates/pet-env-var-path/src/lib.rs
+++ b/crates/pet-env-var-path/src/lib.rs
@@ -14,11 +14,21 @@ pub fn get_search_paths_from_env_variables(environment: &dyn Environment) -> Vec
             .join("Microsoft")
             .join("WindowsApps");
 
+        // Ignore
+        let mut paths_to_ignore = vec![];
+
+        if std::env::consts::OS != "macos" && std::env::consts::OS != "windows" {
+            // Ignore these as they will be found in linux global.
+            paths_to_ignore.push(PathBuf::from("/bin"));
+            paths_to_ignore.push(PathBuf::from("/usr/bin"));
+            paths_to_ignore.push(PathBuf::from("/usr/local/bin"));
+        }
         environment
             .get_know_global_search_locations()
             .clone()
             .into_iter()
             .filter(|p| !p.starts_with(apps_path.clone()))
+            .filter(|p| !paths_to_ignore.contains(p))
             .collect::<Vec<PathBuf>>()
     } else {
         Vec::new()

--- a/crates/pet/src/lib.rs
+++ b/crates/pet/src/lib.rs
@@ -5,7 +5,7 @@ use find::find_and_report_envs;
 use locators::create_locators;
 use pet_conda::Conda;
 use pet_core::{os_environment::EnvironmentApi, Configuration};
-use pet_reporter::{self, cache::CacheReporter, stdio};
+use pet_reporter::{self, cache::CacheReporterImpl, stdio};
 use std::{collections::BTreeMap, env, sync::Arc, time::SystemTime};
 
 pub mod find;
@@ -21,7 +21,7 @@ pub fn find_and_report_envs_stdio(print_list: bool, print_summary: bool, verbose
     let now = SystemTime::now();
 
     let stdio_reporter = Arc::new(stdio::create_reporter(print_list));
-    let reporter = CacheReporter::new(stdio_reporter.clone());
+    let reporter = CacheReporterImpl::new(stdio_reporter.clone());
     let environment = EnvironmentApi::new();
     let conda_locator = Arc::new(Conda::from(&environment));
 


### PR DESCRIPTION
This ensures we do not try to discover something when it has already been discovered.
A side effect of not fixing is, is that on linux some exes can get spawned 3 times, and if there are symlinks (100% of time there are on linux), then we end up with 

Total number of spawns = 3 x Number of symlinks x Number of Python exes 
Now is just 1 per environment.