### PR TITLE
Build from Azure Pipelines

### DIFF
--- a/azure-pipelines/README.md
+++ b/azure-pipelines/README.md
@@ -1,0 +1,5 @@
+pre-release.yml: This should build from the `main` branch and publish to the Azure Pipeline feed. This will be consumed by extensions that are also doing pre-release builds. Signing is required on this build.
+
+stable.yml: This should build from the `release/*` branch and publish to the Azure Pipeline feed. This will be consumed by extensions when publishing stable builds. Signing is required on this build.
+
+playground.yml: This pipeline is for engineering/testing purposes so we can do fixes and tests without affecting the pipeline feeds. This will not publish to the Azure Pipeline feed. Signing is not required on this build.

--- a/azure-pipelines/playground.yml
+++ b/azure-pipelines/playground.yml
@@ -1,0 +1,54 @@
+trigger: none
+pr: none
+# Should only ever be manually run.
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: microsoft/vscode-engineering
+      ref: kanadig/rust-binaries1 # TODO: Change this to `main` after `kanadig/rust-binaries1` is merged to `main`.
+      endpoint: Monaco
+
+extends:
+  template: azure-pipelines/extension/pipeline.yml@templates
+  parameters:
+    ghCreateTag: false
+    binaryName: "pet"
+    signing: false
+    buildWasm: false
+
+    buildPlatforms:
+      - name: Linux
+        vsceTarget: "web"
+      - name: Linux
+        packageArch: arm64
+        vsceTarget: linux-arm64
+      - name: Linux
+        packageArch: arm
+        vsceTarget: linux-armhf
+      - name: Linux
+        packageArch: x64
+        vsceTarget: linux-x64
+      - name: Linux
+        packageArch: arm64
+        vsceTarget: alpine-arm64
+      - name: Linux
+        packageArch: x64
+        vsceTarget: alpine-x64
+      - name: MacOS
+        packageArch: arm64
+        vsceTarget: darwin-arm64
+      - name: MacOS
+        packageArch: x64
+        vsceTarget: darwin-x64
+      - name: Windows
+        packageArch: arm
+        vsceTarget: win32-arm64
+      - name: Windows
+        packageArch: x64
+        vsceTarget: win32-x64
+
+    preBuildSteps:
+      - pwsh: Rename-Item -Path "./.cargo/config.toml.disabled" -NewName "config.toml"
+        displayName: "Enable Azure Build config for Rust"

--- a/azure-pipelines/pre-release.yml
+++ b/azure-pipelines/pre-release.yml
@@ -1,0 +1,62 @@
+# Run on a schedule
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 10 * * 1-5" # 10AM UTC (2AM PDT) MON-FRI (VS Code Pre-release builds at 9PM PDT)
+    displayName: Nightly Pre-Release Schedule
+    always: false # only run if there are source code changes
+    branches:
+      include:
+        - main
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: microsoft/vscode-engineering
+      ref: kanadig/rust-binaries1 # TODO: Change this to `main` after `kanadig/rust-binaries1` is merged to `main`.
+      endpoint: Monaco
+
+extends:
+  template: azure-pipelines/extension/pipeline.yml@templates
+  parameters:
+    ghCreateTag: false
+    binaryName: "pet"
+    signing: false # TODO: remove this before consuming in extensions (currently extensions build and sign directly)
+    buildWasm: false
+
+    buildPlatforms:
+      - name: Linux
+        vsceTarget: "web"
+      - name: Linux
+        packageArch: arm64
+        vsceTarget: linux-arm64
+      - name: Linux
+        packageArch: arm
+        vsceTarget: linux-armhf
+      - name: Linux
+        packageArch: x64
+        vsceTarget: linux-x64
+      - name: Linux
+        packageArch: arm64
+        vsceTarget: alpine-arm64
+      - name: Linux
+        packageArch: x64
+        vsceTarget: alpine-x64
+      - name: MacOS
+        packageArch: arm64
+        vsceTarget: darwin-arm64
+      - name: MacOS
+        packageArch: x64
+        vsceTarget: darwin-x64
+      - name: Windows
+        packageArch: arm
+        vsceTarget: win32-arm64
+      - name: Windows
+        packageArch: x64
+        vsceTarget: win32-x64
+
+    preBuildSteps:
+      - pwsh: Rename-Item -Path "./.cargo/config.toml.disabled" -NewName "config.toml"
+        displayName: "Enable Azure Build config for Rust"

--- a/azure-pipelines/stable.yml
+++ b/azure-pipelines/stable.yml
@@ -1,0 +1,54 @@
+trigger: none
+pr: none
+# Should only ever be manually run.
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: microsoft/vscode-engineering
+      ref: kanadig/rust-binaries1 # TODO: Change this to `main` after `kanadig/rust-binaries1` is merged to `main`.
+      endpoint: Monaco
+
+extends:
+  template: azure-pipelines/extension/pipeline.yml@templates
+  parameters:
+    ghCreateTag: false
+    binaryName: "pet"
+    signing: false # TODO: remove this before consuming in extensions (currently extensions build and sign directly)
+    buildWasm: false
+
+    buildPlatforms:
+      - name: Linux
+        vsceTarget: "web"
+      - name: Linux
+        packageArch: arm64
+        vsceTarget: linux-arm64
+      - name: Linux
+        packageArch: arm
+        vsceTarget: linux-armhf
+      - name: Linux
+        packageArch: x64
+        vsceTarget: linux-x64
+      - name: Linux
+        packageArch: arm64
+        vsceTarget: alpine-arm64
+      - name: Linux
+        packageArch: x64
+        vsceTarget: alpine-x64
+      - name: MacOS
+        packageArch: arm64
+        vsceTarget: darwin-arm64
+      - name: MacOS
+        packageArch: x64
+        vsceTarget: darwin-x64
+      - name: Windows
+        packageArch: arm
+        vsceTarget: win32-arm64
+      - name: Windows
+        packageArch: x64
+        vsceTarget: win32-x64
+
+    preBuildSteps:
+      - pwsh: Rename-Item -Path "./.cargo/config.toml.disabled" -NewName "config.toml"
+        displayName: "Enable Azure Build config for Rust"


### PR DESCRIPTION
Currently, extensions that we ship have to build this binary themselves. This PR will allow us to build these once and consume the packages during extension build.