### PR TITLE
Fix typo: only activate.* should be counted for virtualenvs

### DIFF
--- a/crates/pet-virtualenv/src/lib.rs
+++ b/crates/pet-virtualenv/src/lib.rs
@@ -62,7 +62,7 @@ pub fn is_virtualenv_dir(path: &Path) -> bool {
                 .unwrap_or_default()
                 .to_str()
                 .unwrap_or_default()
-                .starts_with("activate")
+                .starts_with("activate.")
             {
                 return true;
             }


### PR DESCRIPTION
Recently ran into a QoL issue in VSCode where my Homebrew installations of `python3` were being counted as "Virtual Environments". There are several Homebrew packages that install to the `/opt/homebrew/bin` directory (where Python does) that start with the pattern `activate*`.

For example, `activate-global-python-argcomplete`. 

Really, we should only consider it a virtual environment directory if the activate script we look for has some arbitrary _extension_, not just starts with the string `activate`. Hopefully this can save people in the future from going down the rabbit hole I did.