### PR TITLE
Avoid misdetecting global Linux Python as virtualenv

### DIFF
--- a/crates/pet-virtualenv/src/lib.rs
+++ b/crates/pet-virtualenv/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use pet_core::{
     env::PythonEnv,
@@ -40,6 +40,19 @@ pub fn is_virtualenv_dir(path: &Path) -> bool {
             path = path.join("bin");
         }
     }
+
+    // Never consider global locations to be virtualenvs
+    // in case there is a false positive match from checks below.
+    if vec![
+        PathBuf::from(r"/bin"),
+        PathBuf::from(r"/usr/bin"),
+        PathBuf::from(r"/usr/local/bin"),
+    ]
+    .contains(&path)
+    {
+        return false;
+    }
+
     // Check if there are any activate.* files in the same directory as the interpreter.
     //
     // env
@@ -62,7 +75,7 @@ pub fn is_virtualenv_dir(path: &Path) -> bool {
                 .unwrap_or_default()
                 .to_str()
                 .unwrap_or_default()
-                .starts_with("activate")
+                .starts_with("activate.")
             {
                 return true;
             }

--- a/crates/pet-virtualenv/src/lib.rs
+++ b/crates/pet-virtualenv/src/lib.rs
@@ -43,7 +43,7 @@ pub fn is_virtualenv_dir(path: &Path) -> bool {
 
     // Never consider global locations to be virtualenvs
     // in case there is a false positive match from checks below.
-    if vec![
+    if [
         PathBuf::from(r"/bin"),
         PathBuf::from(r"/usr/bin"),
         PathBuf::from(r"/usr/local/bin"),


### PR DESCRIPTION
`/usr/bin` on Linux might contain unrelated `activate.*` binaries
which would make `is_virtualenv_dir` mistake it for a virtualenv:

	Environment (VirtualEnv)
	   Executable  : /usr/bin/python
	   Symlinks    : "/usr/bin/python"

	Environment (VirtualEnv)
	   Executable  : /bin/python
	   Symlinks    : "/bin/python"

	Environment (VirtualEnv)
	   Executable  : /usr/bin/python3
	   Symlinks    : "/usr/bin/python3"

	Environment (VirtualEnv)
	   Executable  : /bin/python3
	   Symlinks    : "/bin/python3"

	Environment (VirtualEnv)
	   Executable  : /usr/bin/python3.10
	   Symlinks    : "/usr/bin/python3.10"

	Environment (VirtualEnv)
	   Executable  : /bin/python3.10
	   Symlinks    : "/bin/python3.10"

	Environment (VirtualEnv)
	   Executable  : /usr/bin/python3.11
	   Symlinks    : "/usr/bin/python3.11"

This fix reduces the likelihood of this happening by excluding the
common `bin` directories as well as tightening the `activate` test
to avoid matching binaries like `activate-ssh-agent`.
