### PR TITLE
Fix env duplication on merged-usr systems

### DIFF
--- a/crates/pet-env-var-path/src/lib.rs
+++ b/crates/pet-env-var-path/src/lib.rs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 use pet_core::os_environment::Environment;
+use std::collections::HashSet;
+use std::fs;
 use std::path::PathBuf;
 
 pub fn get_search_paths_from_env_variables(environment: &dyn Environment) -> Vec<PathBuf> {
@@ -16,10 +18,12 @@ pub fn get_search_paths_from_env_variables(environment: &dyn Environment) -> Vec
 
         environment
             .get_know_global_search_locations()
-            .clone()
+            .into_iter()
+            .map(|p| fs::canonicalize(&p).unwrap_or(p))
+            .collect::<HashSet<PathBuf>>()
             .into_iter()
             .filter(|p| !p.starts_with(apps_path.clone()))
-            .collect::<Vec<PathBuf>>()
+            .collect()
     } else {
         Vec::new()
     }


### PR DESCRIPTION
On modern (merged-usr) Linux systems, `/bin`, `/sbin` and `/usr/sbin`
are symlinks to `/usr/bin`.  There is no point in reporting the same
Python installation four times, so canonicalize search paths before
searching.

Before:

	Breakdown for finding Environments:
	-----------------------------------
	GlobalVirtualEnvs    : 17.412201ms
	Locators             : 225.284494ms
	Path                 : 433.162905ms
	Workspaces           : 2.161556ms

	Environments (41):
	------------------
	GlobalPaths          : 14
	LinuxGlobal          : 16
	VirtualEnvWrapper    : 11

After:

	Breakdown for finding Environments:
	-----------------------------------
	GlobalVirtualEnvs    : 16.595382ms
	Locators             : 223.759511ms
	Path                 : 313.276036ms
	Workspaces           : 1.418024ms

	Environments (21):
	------------------
	GlobalPaths          : 2
	LinuxGlobal          : 8
	VirtualEnvWrapper    : 11
