### PR TITLE
fix(poetry): pep503 normalize package name

### DIFF
--- a/crates/pet-poetry/src/pyproject_toml.rs
+++ b/crates/pet-poetry/src/pyproject_toml.rs
@@ -96,4 +96,30 @@ build-backend = "poetry.core.masonry.api"
             "poetry-demo"
         );
     }
+
+    #[test]
+    fn extract_normalized_name_from_pyproject_toml() {
+        let cfg = r#"
+[tool.poetry]
+name = "poetry_.demo"
+version = "0.1.0"
+description = ""
+authors = ["User Name <bogus.user@some.email.com>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.12"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+"#;
+        assert_eq!(
+            parse_contents(cfg, Path::new("pyproject.toml"))
+                .unwrap()
+                .name,
+            "poetry-demo"
+        );
+    }
 }

--- a/crates/pet-poetry/src/pyproject_toml.rs
+++ b/crates/pet-poetry/src/pyproject_toml.rs
@@ -6,7 +6,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use lazy_static::lazy_static;
 use log::{error, trace};
+use regex::Regex;
+
+lazy_static! {
+    static ref NORMALIZE_NAME: Regex = Regex::new(r"[-_.]+")
+        .expect("Error generating RegEx for poetry project name normalization");
+}
 
 #[derive(Debug)]
 pub struct PyProjectToml {
@@ -15,8 +22,17 @@ pub struct PyProjectToml {
 
 impl PyProjectToml {
     fn new(name: String, file: PathBuf) -> Self {
-        trace!("Poetry project: {:?} with name {:?}", file, name);
-        PyProjectToml { name }
+        // Source from https://github.com/python-poetry/poetry-core/blob/a2c068227358984d835c9684de723b046bdcd67a/src/poetry/core/_vendor/packaging/utils.py#L46-L51
+        // normalized_name = re.sub(r"[-_.]+", "-", name).lower()
+        let normalized_name = NORMALIZE_NAME
+            .replace_all(&name.to_lowercase(), "-")
+            .chars()
+            .collect::<String>();
+
+        trace!("Poetry project: {:?} with name {:?}", file, normalized_name);
+        PyProjectToml {
+            name: normalized_name,
+        }
     }
     pub fn find(path: &Path) -> Option<Self> {
         trace!("Finding poetry file in {:?}", path);


### PR DESCRIPTION
# Issue

When generating the name of the virtualenv, Poetry honors PEP 503 project name normalization [^1]. In short, the name of the project is lowercased, and all runs of `-_.` are replaced with a single `-`.

For example, the normalized name of the following extract of pyproject.toml is `my-project`.

```toml
[project]
name = "my_project"
```

When a project name is modified like this by Poetry, the virtualenv name generated by this project will not match and the Poetry locator will not pick up any Poetry virtual environments (with the exception of the in-project `.venv`).

# PR Description

This PR ports the few lines of Python code from poetry-core [^2] that implement the name normalization to the Poetry locator in order to fix this unaligned behavior.


[^1]: https://peps.python.org/pep-0503/#normalized-names
[^2]: https://github.com/python-poetry/poetry-core/blob/a2c068227358984d835c9684de723b046bdcd67a/src/poetry/core/_vendor/packaging/utils.py#L46-L51