### PR TITLE
Run commands without creating a console window on Windows

### DIFF
--- a/crates/pet-conda/src/conda_info.rs
+++ b/crates/pet-conda/src/conda_info.rs
@@ -3,6 +3,7 @@
 
 use log::{error, trace, warn};
 use pet_fs::path::resolve_symlink;
+use pet_python_utils::executable::new_silent_command;
 use std::path::PathBuf;
 
 #[derive(Debug, serde::Deserialize)]
@@ -45,7 +46,7 @@ impl CondaInfo {
             resolve_symlink(&executable).unwrap_or(executable)
         };
 
-        let result = std::process::Command::new(&executable)
+        let result = new_silent_command(&executable)
             .arg("info")
             .arg("--json")
             .output();

--- a/crates/pet-poetry/src/environment_locations_spawn.rs
+++ b/crates/pet-poetry/src/environment_locations_spawn.rs
@@ -4,6 +4,7 @@
 use lazy_static::lazy_static;
 use log::{error, trace};
 use pet_core::python_environment::PythonEnvironment;
+use pet_python_utils::executable::new_silent_command;
 use regex::Regex;
 use std::{path::PathBuf, time::SystemTime};
 
@@ -36,7 +37,7 @@ pub fn list_environments(
 
 fn get_environments(executable: &PathBuf, workspace_dir: &PathBuf) -> Option<Vec<PathBuf>> {
     let start = SystemTime::now();
-    let result = std::process::Command::new(executable)
+    let result = new_silent_command(executable)
         .arg("env")
         .arg("list")
         .arg("--full-path")

--- a/crates/pet-python-utils/src/env.rs
+++ b/crates/pet-python-utils/src/env.rs
@@ -9,7 +9,7 @@ use std::{
     time::SystemTime,
 };
 
-use crate::cache::create_cache;
+use crate::{cache::create_cache, executable::new_silent_command};
 
 const PYTHON_INFO_JSON_SEPARATOR: &str = "093385e9-59f7-4a16-a604-14bf206256fe";
 const PYTHON_INFO_CMD:&str = "import json, sys; print('093385e9-59f7-4a16-a604-14bf206256fe');print(json.dumps({'version': '.'.join(str(n) for n in sys.version_info), 'sys_prefix': sys.prefix, 'executable': sys.executable, 'is64_bit': sys.maxsize > 2**32}))";
@@ -92,7 +92,7 @@ fn get_interpreter_details(executable: &Path) -> Option<ResolvedPythonEnv> {
     let executable = executable.to_str()?;
     let start = SystemTime::now();
     trace!("Executing Python: {} -c {}", executable, PYTHON_INFO_CMD);
-    let result = std::process::Command::new(executable)
+    let result = new_silent_command(executable)
         .args(["-c", PYTHON_INFO_CMD])
         .output();
     match result {

--- a/crates/pet-python-utils/src/executable.rs
+++ b/crates/pet-python-utils/src/executable.rs
@@ -4,6 +4,7 @@
 use lazy_static::lazy_static;
 use log::trace;
 use regex::Regex;
+use std::ffi::OsStr;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -157,6 +158,22 @@ pub fn should_search_for_environments_in_path<P: AsRef<Path>>(path: &P) -> bool 
     }
 
     true
+}
+
+#[cfg(target_os = "windows")]
+pub fn new_silent_command(program: impl AsRef<OsStr>) -> std::process::Command {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+    let mut command = std::process::Command::new(program);
+    command.creation_flags(CREATE_NO_WINDOW);
+    command
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn new_silent_command(program: impl AsRef<OsStr>) -> std::process::Command {
+    std::process::Command::new(program)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Running a console program (like `python.exe`) from a GUI application (such as an IDE) will create a new console window by default. This will cause a console window to briefly appear whenever the IDE uses PET. To fix this, tell Windows to hide this console window.