### PR TITLE
fix: update tracing subscriber to write JSON output to stderr

### DIFF
--- a/crates/pet/src/lib.rs
+++ b/crates/pet/src/lib.rs
@@ -47,7 +47,7 @@ pub fn initialize_tracing(verbose: bool) {
         if use_json {
             tracing_subscriber::registry()
                 .with(filter)
-                .with(fmt::layer().json())
+                .with(fmt::layer().json().with_writer(std::io::stderr))
                 .init();
         } else {
             tracing_subscriber::registry()
@@ -55,7 +55,8 @@ pub fn initialize_tracing(verbose: bool) {
                 .with(
                     fmt::layer()
                         .with_target(true)
-                        .with_timer(fmt::time::uptime()),
+                        .with_timer(fmt::time::uptime())
+                        .with_writer(std::io::stderr),
                 )
                 .init();
         }


### PR DESCRIPTION
What broke: The commit added performance tracing/logging code. The new code was using a library called tracing-subscriber which, by default, writes log messages to stdout. This corrupted the JSONRPC protocol, causing the "Connection Error" and endless loading.

Fix: tracing library to write to stderr (standard error) instead of stdout.

resolves: https://github.com/microsoft/python-environment-tools/issues/341