### PR TITLE
feat: centralize SemVer versioning with nightly/stable pipeline support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
+version = "0.1.0"
+edition = "2021"
 license = "MIT"
 
 [profile.release]

--- a/azure-pipelines/pre-release.yml
+++ b/azure-pipelines/pre-release.yml
@@ -52,3 +52,5 @@ extends:
     preBuildSteps:
       - pwsh: Rename-Item -Path "./.cargo/config.toml.disabled" -NewName "config.toml"
         displayName: "Enable Azure Build config for Rust"
+      - pwsh: ./set-version.ps1 -Suffix "dev.$(Build.BuildId)"
+        displayName: "Set nightly version"

--- a/crates/pet-conda/Cargo.toml
+++ b/crates/pet-conda/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-conda"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-core/Cargo.toml
+++ b/crates/pet-core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-core"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-env-var-path/Cargo.toml
+++ b/crates/pet-env-var-path/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-env-var-path"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-fs/Cargo.toml
+++ b/crates/pet-fs/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-fs"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-global-virtualenvs/Cargo.toml
+++ b/crates/pet-global-virtualenvs/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-global-virtualenvs"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-homebrew/Cargo.toml
+++ b/crates/pet-homebrew/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-homebrew"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-jsonrpc/Cargo.toml
+++ b/crates/pet-jsonrpc/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-jsonrpc"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-linux-global-python/Cargo.toml
+++ b/crates/pet-linux-global-python/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-linux-global-python"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-mac-commandlinetools/Cargo.toml
+++ b/crates/pet-mac-commandlinetools/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-mac-commandlinetools"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-mac-python-org/Cargo.toml
+++ b/crates/pet-mac-python-org/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-mac-python-org"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-mac-xcode/Cargo.toml
+++ b/crates/pet-mac-xcode/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-mac-xcode"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-pipenv/Cargo.toml
+++ b/crates/pet-pipenv/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-pipenv"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-pixi/Cargo.toml
+++ b/crates/pet-pixi/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-pixi"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-poetry/Cargo.toml
+++ b/crates/pet-poetry/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-poetry"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-pyenv/Cargo.toml
+++ b/crates/pet-pyenv/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-pyenv"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-python-utils/Cargo.toml
+++ b/crates/pet-python-utils/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-python-utils"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-reporter/Cargo.toml
+++ b/crates/pet-reporter/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-reporter"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-telemetry/Cargo.toml
+++ b/crates/pet-telemetry/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-telemetry"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-uv/Cargo.toml
+++ b/crates/pet-uv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pet-uv"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license.workspace = true
 
 [dependencies]

--- a/crates/pet-venv/Cargo.toml
+++ b/crates/pet-venv/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-venv"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-virtualenv/Cargo.toml
+++ b/crates/pet-virtualenv/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-virtualenv"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-virtualenvwrapper/Cargo.toml
+++ b/crates/pet-virtualenvwrapper/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-virtualenvwrapper"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 msvc_spectre_libs = { version = "0.1.1", features = ["error"] }

--- a/crates/pet-windows-registry/Cargo.toml
+++ b/crates/pet-windows-registry/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-windows-registry"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55.0"

--- a/crates/pet-windows-store/Cargo.toml
+++ b/crates/pet-windows-store/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-windows-store"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55.0"

--- a/crates/pet-winpython/Cargo.toml
+++ b/crates/pet-winpython/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet-winpython"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 pet-core = { path = "../pet-core" }

--- a/crates/pet/Cargo.toml
+++ b/crates/pet/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pet"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 pet-windows-store = { path = "../pet-windows-store" }

--- a/set-version.ps1
+++ b/set-version.ps1
@@ -1,0 +1,77 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Sets the version for the PET workspace and all crates.
+
+.DESCRIPTION
+    Updates the workspace version in the root Cargo.toml. All sub-crates inherit
+    this version via `version.workspace = true`.
+
+    For nightly/pre-release builds, pass a pre-release suffix. The base version is
+    read from Cargo.toml automatically (or overridden with -Version). Use a
+    deterministic pipeline variable (e.g., Build.BuildId) as the suffix to ensure
+    all platform builds in the same pipeline run get the same version number.
+
+.PARAMETER Version
+    Optional base SemVer version (e.g., "0.2.0"). If omitted, reads the current
+    version from the workspace Cargo.toml.
+
+.PARAMETER Suffix
+    Optional pre-release suffix appended as "-<Suffix>" (e.g., "dev.12345").
+    For nightly builds, use the Azure Pipelines Build.BuildId to guarantee
+    all platforms in the same run get an identical version.
+
+.EXAMPLE
+    # Stable release — explicit version
+    ./set-version.ps1 -Version 1.0.0
+
+.EXAMPLE
+    # Nightly build — reads base version from Cargo.toml, appends suffix
+    ./set-version.ps1 -Suffix "dev.$(Build.BuildId)"
+#>
+
+param(
+    [Parameter(Mandatory = $false)]
+    [ValidatePattern('^\d+\.\d+\.\d+$')]
+    [string]$Version,
+
+    [Parameter(Mandatory = $false)]
+    [ValidatePattern('^[a-zA-Z0-9._-]+$')]
+    [string]$Suffix
+)
+
+$ErrorActionPreference = 'Stop'
+
+$cargoToml = Join-Path $PSScriptRoot 'Cargo.toml'
+$content = Get-Content $cargoToml -Raw
+
+# NOTE: Assumes `version` is the first key after [workspace.package] header.
+$pattern = '(?m)(^\[workspace\.package\]\s*\r?\nversion\s*=\s*)"([^"]*)"'
+if ($content -notmatch $pattern) {
+    Write-Error "Could not find [workspace.package] version in $cargoToml"
+    exit 1
+}
+
+# Read current version from Cargo.toml if -Version not provided
+if (-not $Version) {
+    $Version = $Matches[2]
+    # Strip any existing pre-release suffix to get the base version
+    $Version = ($Version -split '-')[0]
+    Write-Host "Read base version from Cargo.toml: $Version"
+}
+
+if ($Suffix) {
+    $fullVersion = "$Version-$Suffix"
+} else {
+    $fullVersion = $Version
+}
+
+Write-Host "Setting PET version to: $fullVersion"
+
+$content = $content -replace $pattern, "`${1}`"$fullVersion`""
+Set-Content $cargoToml $content -NoNewline -Encoding utf8
+
+Write-Host "Updated $cargoToml"
+Write-Host "Version set to: $fullVersion"


### PR DESCRIPTION
Centralizes SemVer versioning so nightly and stable releases get proper version numbers, with all platform builds in the same pipeline run guaranteed to use the same version.

### Changes

- Add `version`, `edition` to `[workspace.package]` in root `Cargo.toml` — single source of truth
- All 26 sub-crates inherit via `version.workspace = true`
- New `set-version.ps1` script: reads base version from `Cargo.toml`, optionally appends a pre-release suffix
- Pre-release pipeline calls `./set-version.ps1 -Suffix "dev.$(Build.BuildId)"` — `Build.BuildId` is pipeline-scoped, ensuring all platform agents get the same version
- Stable pipeline uses the version from `Cargo.toml` as-is (no script call needed)
- Suffix parameter validated with `[ValidatePattern('^[a-zA-Z0-9._-]+$')]` to prevent TOML injection

### Usage

```powershell
# Stable: explicit version bump (edit Cargo.toml, or use the script)
./set-version.ps1 -Version 1.0.0

# Nightly: auto-reads base version, appends deterministic suffix
./set-version.ps1 -Suffix "dev.$(Build.BuildId)"
```

Fixes #348