### PR TITLE
feat: add --json flag to find and resolve commands

### DIFF
--- a/crates/pet/src/main.rs
+++ b/crates/pet/src/main.rs
@@ -53,6 +53,10 @@ enum Commands {
         /// Will not search in the workspace directories.
         #[arg(short, long, conflicts_with = "workspace")]
         kind: Option<PythonEnvironmentKind>,
+
+        /// Output results as JSON.
+        #[arg(short, long)]
+        json: bool,
     },
     /// Resolves & reports the details of the the environment to the standard output.
     Resolve {
@@ -67,6 +71,10 @@ enum Commands {
         /// Whether to display verbose output (defaults to warnings).
         #[arg(short, long)]
         verbose: bool,
+
+        /// Output results as JSON.
+        #[arg(short, long)]
+        json: bool,
     },
     /// Starts the JSON RPC Server.
     Server,
@@ -83,6 +91,7 @@ fn main() {
         workspace: false,
         cache_directory: None,
         kind: None,
+        json: false,
     }) {
         Commands::Find {
             list,
@@ -92,6 +101,7 @@ fn main() {
             workspace,
             cache_directory,
             kind,
+            json,
         } => {
             let mut workspace_only = workspace;
             if search_paths.clone().is_some()
@@ -113,13 +123,15 @@ fn main() {
                 workspace_only,
                 cache_directory,
                 kind,
+                json,
             });
         }
         Commands::Resolve {
             executable,
             verbose,
             cache_directory,
-        } => resolve_report_stdio(executable, verbose, cache_directory),
+            json,
+        } => resolve_report_stdio(executable, verbose, cache_directory, json),
         Commands::Server => start_jsonrpc_server(),
     }
 }


### PR DESCRIPTION
Adds a `--json` / `-j` flag to the `find` and `resolve` CLI commands for simple one-shot JSON output without needing the JSONRPC server.

- `pet find --json` outputs `{ "managers": [...], "environments": [...] }` 
- `pet resolve --json <exe>` outputs the resolved `PythonEnvironment` object (or `null`)
- All other flags (`--list`, `--verbose`, `--report-missing`, etc.) continue to work as before
- JSON serialization uses `camelCase` field naming consistent with the JSONRPC API
- Summary/timing output is suppressed in JSON mode to keep stdout clean

Fixes #87