### PR TITLE
feat: add missing CLI arguments for find command with env var fallbacks

### DIFF
--- a/crates/pet/Cargo.toml
+++ b/crates/pet/Cargo.toml
@@ -43,7 +43,7 @@ pet-uv = { path = "../pet-uv" }
 log = "0.4.21"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-clap = { version = "4.5.4", features = ["derive", "cargo"] }
+clap = { version = "4.5.4", features = ["derive", "cargo", "env"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 env_logger = "0.10.2"

--- a/crates/pet/src/lib.rs
+++ b/crates/pet/src/lib.rs
@@ -75,6 +75,10 @@ pub struct FindOptions {
     pub cache_directory: Option<PathBuf>,
     pub kind: Option<PythonEnvironmentKind>,
     pub json: bool,
+    pub conda_executable: Option<PathBuf>,
+    pub pipenv_executable: Option<PathBuf>,
+    pub poetry_executable: Option<PathBuf>,
+    pub environment_directories: Option<Vec<PathBuf>>,
 }
 
 pub fn find_and_report_envs_stdio(options: FindOptions) {
@@ -161,6 +165,14 @@ fn create_config(options: &FindOptions) -> Configuration {
             .collect(),
     );
 
+    config.conda_executable = options.conda_executable.clone();
+    config.pipenv_executable = options.pipenv_executable.clone();
+    config.poetry_executable = options.poetry_executable.clone();
+    config.environment_directories = options
+        .environment_directories
+        .clone()
+        .map(|dirs| dirs.into_iter().filter(|p| p.is_dir()).collect());
+
     config
 }
 
@@ -185,8 +197,10 @@ fn find_envs(
         // By now all conda envs have been found
         // Spawn conda
         // & see if we can find more environments by spawning conda.
-        let _ = conda_locator.find_and_report_missing_envs(&reporter, None);
-        let _ = poetry_locator.find_and_report_missing_envs(&reporter, None);
+        let _ =
+            conda_locator.find_and_report_missing_envs(&reporter, options.conda_executable.clone());
+        let _ = poetry_locator
+            .find_and_report_missing_envs(&reporter, options.poetry_executable.clone());
     }
 
     if options.print_summary {
@@ -292,8 +306,10 @@ fn find_envs_json(
 
     find_and_report_envs(&reporter, config, locators, environment, search_scope);
     if options.report_missing {
-        let _ = conda_locator.find_and_report_missing_envs(&reporter, None);
-        let _ = poetry_locator.find_and_report_missing_envs(&reporter, None);
+        let _ =
+            conda_locator.find_and_report_missing_envs(&reporter, options.conda_executable.clone());
+        let _ = poetry_locator
+            .find_and_report_missing_envs(&reporter, options.poetry_executable.clone());
     }
 
     let managers = collect_reporter

--- a/crates/pet/src/main.rs
+++ b/crates/pet/src/main.rs
@@ -33,7 +33,7 @@ enum Commands {
         list: bool,
 
         /// Directory to cache the environment information after spawning Python.
-        #[arg(short, long)]
+        #[arg(short, long, env = "PET_CACHE_DIRECTORY")]
         cache_directory: Option<PathBuf>,
 
         /// Display verbose output (defaults to warnings).
@@ -57,6 +57,23 @@ enum Commands {
         /// Output results as JSON.
         #[arg(short, long)]
         json: bool,
+
+        /// Path to the conda or mamba executable.
+        #[arg(long, env = "PET_CONDA_EXECUTABLE")]
+        conda_executable: Option<PathBuf>,
+
+        /// Path to the pipenv executable.
+        #[arg(long, env = "PET_PIPENV_EXECUTABLE")]
+        pipenv_executable: Option<PathBuf>,
+
+        /// Path to the poetry executable.
+        #[arg(long, env = "PET_POETRY_EXECUTABLE")]
+        poetry_executable: Option<PathBuf>,
+
+        /// Additional directories where virtual environments can be found.
+        /// Use comma-separated values when setting via the environment variable.
+        #[arg(long, env = "PET_ENVIRONMENT_DIRECTORIES", value_delimiter = ',')]
+        environment_directories: Option<Vec<PathBuf>>,
     },
     /// Resolves & reports the details of the the environment to the standard output.
     Resolve {
@@ -65,7 +82,7 @@ enum Commands {
         executable: PathBuf,
 
         /// Directory to cache the environment information after spawning Python.
-        #[arg(short, long)]
+        #[arg(short, long, env = "PET_CACHE_DIRECTORY")]
         cache_directory: Option<PathBuf>,
 
         /// Whether to display verbose output (defaults to warnings).
@@ -92,6 +109,10 @@ fn main() {
         cache_directory: None,
         kind: None,
         json: false,
+        conda_executable: None,
+        pipenv_executable: None,
+        poetry_executable: None,
+        environment_directories: None,
     }) {
         Commands::Find {
             list,
@@ -102,6 +123,10 @@ fn main() {
             cache_directory,
             kind,
             json,
+            conda_executable,
+            pipenv_executable,
+            poetry_executable,
+            environment_directories,
         } => {
             let mut workspace_only = workspace;
             if search_paths.clone().is_some()
@@ -124,6 +149,10 @@ fn main() {
                 cache_directory,
                 kind,
                 json,
+                conda_executable,
+                pipenv_executable,
+                poetry_executable,
+                environment_directories,
             });
         }
         Commands::Resolve {


### PR DESCRIPTION
Adds CLI arguments to the `find` command that mirror the JSONRPC server's `configure` options, with `PET_*` environment variable fallbacks via clap's `env` attribute.

## Changes

- Add `--conda-executable` / `PET_CONDA_EXECUTABLE` to `find`
- Add `--pipenv-executable` / `PET_PIPENV_EXECUTABLE` to `find`
- Add `--poetry-executable` / `PET_POETRY_EXECUTABLE` to `find`
- Add `--environment-directories` / `PET_ENVIRONMENT_DIRECTORIES` (comma-delimited) to `find`
- Add `PET_CACHE_DIRECTORY` env var fallback to existing `--cache-directory` on both `find` and `resolve`
- Wire new options through `FindOptions` → `create_config()` → `Configuration`
- Pass user-provided conda/poetry executables to `find_and_report_missing_envs` (previously hardcoded to `None`)
- Enable clap `env` feature in Cargo.toml

Fixes #353