### PR TITLE
fix: validate executable filename before spawning in resolve_environment (Fixes #364)

### DIFF
--- a/crates/pet-python-utils/src/executable.rs
+++ b/crates/pet-python-utils/src/executable.rs
@@ -180,7 +180,7 @@ pub fn find_executables<T: AsRef<Path>>(env_path: T) -> Vec<PathBuf> {
     python_executables
 }
 
-fn is_python_executable_name(exe: &Path) -> bool {
+pub fn is_python_executable_name(exe: &Path) -> bool {
     let name = exe
         .file_name()
         .unwrap_or_default()

--- a/crates/pet/src/resolve.rs
+++ b/crates/pet/src/resolve.rs
@@ -12,7 +12,10 @@ use pet_core::{
     Locator,
 };
 use pet_env_var_path::get_search_paths_from_env_variables;
-use pet_python_utils::{env::ResolvedPythonEnv, executable::find_executable};
+use pet_python_utils::{
+    env::ResolvedPythonEnv,
+    executable::{find_executable, is_python_executable_name},
+};
 
 use crate::locators::identify_python_environment_using_locators;
 
@@ -49,6 +52,16 @@ pub fn resolve_environment(
             executable
         );
     }
+    // Validate that the executable filename looks like a Python executable
+    // before proceeding with the locator chain or spawning.
+    if executable.is_file() && !is_python_executable_name(&executable) {
+        warn!(
+            "Path {:?} does not look like a Python executable, skipping resolve",
+            executable
+        );
+        return None;
+    }
+
     // First check if this is a known environment
     let env = PythonEnv::new(executable.to_owned(), None, None);
     trace!(


### PR DESCRIPTION
Adds validation in `resolve_environment()` to check that the executable filename matches a Python executable pattern before proceeding with the locator chain or spawning. Previously, any file (e.g., Jupyter kernel spec bash wrapper scripts) would be spawned with `-c "import sys;..."`, wasting ~13 seconds and executing arbitrary non-Python executables.

- Made `is_python_executable_name()` public in `pet-python-utils` to reuse existing regex patterns
- Added early return with `warn!` log in `resolve_environment()` when filename doesn't match

Fixes #364