### PR TITLE
feat: add brace expansion support for glob patterns

### DIFF
--- a/crates/pet-python-utils/src/executable.rs
+++ b/crates/pet-python-utils/src/executable.rs
@@ -180,7 +180,7 @@ pub fn find_executables<T: AsRef<Path>>(env_path: T) -> Vec<PathBuf> {
     python_executables
 }
 
-fn is_python_executable_name(exe: &Path) -> bool {
+pub fn is_python_executable_name(exe: &Path) -> bool {
     let name = exe
         .file_name()
         .unwrap_or_default()

--- a/crates/pet/src/resolve.rs
+++ b/crates/pet/src/resolve.rs
@@ -12,7 +12,10 @@ use pet_core::{
     Locator,
 };
 use pet_env_var_path::get_search_paths_from_env_variables;
-use pet_python_utils::{env::ResolvedPythonEnv, executable::find_executable};
+use pet_python_utils::{
+    env::ResolvedPythonEnv,
+    executable::{find_executable, is_python_executable_name},
+};
 
 use crate::locators::identify_python_environment_using_locators;
 
@@ -49,6 +52,16 @@ pub fn resolve_environment(
             executable
         );
     }
+    // Validate that the executable filename looks like a Python executable
+    // before proceeding with the locator chain or spawning.
+    if executable.is_file() && !is_python_executable_name(&executable) {
+        warn!(
+            "Path {:?} does not look like a Python executable, skipping resolve",
+            executable
+        );
+        return None;
+    }
+
     // First check if this is a known environment
     let env = PythonEnv::new(executable.to_owned(), None, None);
     trace!(


### PR DESCRIPTION
Adds `{a,b}` brace expansion support to glob pattern handling, enabling patterns like `./**/{bin,Scripts}/python{,.exe}` to work as search paths.

## Changes

- **Brace expansion** in `pet-fs/src/glob.rs`: expands `{a,b}` groups before passing patterns to the `glob` crate (which doesn't support braces natively)
- **Safety cap**: expansion limited to 1024 patterns to prevent exponential blowup
- **Progress logging**: trace-level logs during glob expansion showing pattern, match count, and elapsed time
- **Robust detection**: `is_glob_pattern()` now correctly identifies brace patterns (requires matched `{...}` pair with comma)
- **JSONRPC docs**: documented brace expansion syntax and example in `searchPaths`

Fixes #366