### PR TITLE
Only embed Windows resources for binary targets

### DIFF
--- a/crates/pet/build.rs
+++ b/crates/pet/build.rs
@@ -4,6 +4,9 @@
 fn main() {
     #[cfg(target_os = "windows")]
     {
+        if std::env::var("CARGO_BIN_NAME").is_err() {
+            return;
+        }
         let version = std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.1.0".to_string());
 
         let mut res = winresource::WindowsResource::new();


### PR DESCRIPTION
Closes #373 

Ensures winresource only runs when building binary targets by checking the `CARGO_BIN_NAME` environment variable. This prevents resource conflicts when pet is used as a library dependency on Windows.