### PR TITLE
fix: formalize refresh locator state

### DIFF
--- a/crates/pet-conda/src/lib.rs
+++ b/crates/pet-conda/src/lib.rs
@@ -16,7 +16,7 @@ use pet_core::{
     os_environment::Environment,
     python_environment::{PythonEnvironment, PythonEnvironmentKind},
     reporter::Reporter,
-    Locator, LocatorKind,
+    Locator, LocatorKind, RefreshStatePersistence, RefreshStateSyncScope,
 };
 use pet_fs::path::norm_case;
 use rayon::prelude::*;
@@ -216,11 +216,39 @@ impl Locator for Conda {
     fn get_kind(&self) -> LocatorKind {
         LocatorKind::Conda
     }
-    fn configure(&self, config: &pet_core::Configuration) {
-        if let Some(ref conda_exe) = config.conda_executable {
-            let mut conda_executable = self.conda_executable.write().unwrap();
-            conda_executable.replace(conda_exe.clone());
+    fn refresh_state(&self) -> RefreshStatePersistence {
+        RefreshStatePersistence::SyncedDiscoveryState
+    }
+    fn sync_refresh_state_from(&self, source: &dyn Locator, scope: &RefreshStateSyncScope) {
+        let source = source.as_any().downcast_ref::<Conda>().unwrap_or_else(|| {
+            panic!("attempted to sync Conda state from {:?}", source.get_kind())
+        });
+
+        match scope {
+            RefreshStateSyncScope::Full => {}
+            RefreshStateSyncScope::GlobalFiltered(kind)
+                if self.supported_categories().contains(kind) => {}
+            RefreshStateSyncScope::GlobalFiltered(_) | RefreshStateSyncScope::Workspace => {
+                return;
+            }
         }
+
+        self.environments.clear();
+        self.environments
+            .insert_many(source.environments.clone_map());
+
+        self.managers.clear();
+        self.managers.insert_many(source.managers.clone_map());
+
+        self.mamba_managers.clear();
+        self.mamba_managers
+            .insert_many(source.mamba_managers.clone_map());
+    }
+    fn configure(&self, config: &pet_core::Configuration) {
+        self.conda_executable
+            .write()
+            .unwrap()
+            .clone_from(&config.conda_executable);
     }
     fn supported_categories(&self) -> Vec<PythonEnvironmentKind> {
         vec![PythonEnvironmentKind::Conda]

--- a/crates/pet-core/src/lib.rs
+++ b/crates/pet-core/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::path::PathBuf;
+use std::{any::Any, path::PathBuf};
 
 use env::PythonEnv;
 use manager::EnvManager;
@@ -61,7 +61,26 @@ pub enum LocatorKind {
     WindowsStore,
 }
 
-pub trait Locator: Send + Sync {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshStatePersistence {
+    /// The locator keeps no mutable state across requests.
+    Stateless,
+    /// The locator keeps configured inputs only; refresh must not copy them back.
+    ConfiguredOnly,
+    /// The locator keeps cache-like state, but later requests can repopulate it on demand.
+    SelfHydratingCache,
+    /// The locator keeps refresh-discovered state that later requests depend on for correctness.
+    SyncedDiscoveryState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefreshStateSyncScope {
+    Full,
+    GlobalFiltered(PythonEnvironmentKind),
+    Workspace,
+}
+
+pub trait Locator: Any + Send + Sync {
     /// Returns the name of the locator.
     fn get_kind(&self) -> LocatorKind;
     /// Configures the locator with the given configuration.
@@ -100,6 +119,21 @@ pub trait Locator: Send + Sync {
     fn configure(&self, _config: &Configuration) {
         //
     }
+    /// Describes what mutable state, if any, must survive a refresh boundary.
+    ///
+    /// Refresh runs execute against transient locator graphs and then invoke
+    /// `sync_refresh_state_from()` on the long-lived shared locators.
+    fn refresh_state(&self) -> RefreshStatePersistence {
+        RefreshStatePersistence::Stateless
+    }
+    /// Copies correctness-critical post-refresh state from a transient locator into this
+    /// long-lived shared locator.
+    ///
+    /// Override this only when `refresh_state()` returns
+    /// `RefreshStatePersistence::SyncedDiscoveryState`.
+    fn sync_refresh_state_from(&self, _source: &dyn Locator, _scope: &RefreshStateSyncScope) {
+        //
+    }
     /// Returns a list of supported categories for this locator.
     fn supported_categories(&self) -> Vec<PythonEnvironmentKind>;
     /// Given a Python executable, and some optional data like prefix,
@@ -111,4 +145,10 @@ pub trait Locator: Send + Sync {
     fn try_from(&self, env: &PythonEnv) -> Option<PythonEnvironment>;
     /// Finds all environments specific to this locator.
     fn find(&self, reporter: &dyn Reporter);
+}
+
+impl dyn Locator {
+    pub fn as_any(&self) -> &dyn Any {
+        self
+    }
 }

--- a/crates/pet-linux-global-python/src/lib.rs
+++ b/crates/pet-linux-global-python/src/lib.rs
@@ -15,7 +15,7 @@ use pet_core::{
     env::PythonEnv,
     python_environment::{PythonEnvironment, PythonEnvironmentBuilder, PythonEnvironmentKind},
     reporter::Reporter,
-    Locator, LocatorKind,
+    Locator, LocatorKind, RefreshStatePersistence,
 };
 use pet_fs::path::resolve_symlink;
 use pet_python_utils::{env::ResolvedPythonEnv, executable::find_executables};
@@ -61,6 +61,9 @@ impl Default for LinuxGlobalPython {
 impl Locator for LinuxGlobalPython {
     fn get_kind(&self) -> LocatorKind {
         LocatorKind::LinuxGlobal
+    }
+    fn refresh_state(&self) -> RefreshStatePersistence {
+        RefreshStatePersistence::SelfHydratingCache
     }
     fn supported_categories(&self) -> Vec<PythonEnvironmentKind> {
         vec![PythonEnvironmentKind::LinuxGlobal]

--- a/crates/pet-pipenv/src/lib.rs
+++ b/crates/pet-pipenv/src/lib.rs
@@ -11,7 +11,7 @@ use pet_core::LocatorKind;
 use pet_core::{
     python_environment::{PythonEnvironment, PythonEnvironmentBuilder, PythonEnvironmentKind},
     reporter::Reporter,
-    Configuration, Locator,
+    Configuration, Locator, RefreshStatePersistence,
 };
 use pet_fs::path::norm_case;
 use pet_python_utils::executable::find_executables;
@@ -418,10 +418,15 @@ impl Locator for PipEnv {
         LocatorKind::PipEnv
     }
 
+    fn refresh_state(&self) -> RefreshStatePersistence {
+        RefreshStatePersistence::ConfiguredOnly
+    }
+
     fn configure(&self, config: &Configuration) {
-        if let Some(exe) = &config.pipenv_executable {
-            self.pipenv_executable.write().unwrap().replace(exe.clone());
-        }
+        self.pipenv_executable
+            .write()
+            .unwrap()
+            .clone_from(&config.pipenv_executable);
     }
 
     fn supported_categories(&self) -> Vec<PythonEnvironmentKind> {

--- a/crates/pet-poetry/src/lib.rs
+++ b/crates/pet-poetry/src/lib.rs
@@ -11,7 +11,8 @@ use pet_core::{
     os_environment::Environment,
     python_environment::{PythonEnvironment, PythonEnvironmentKind},
     reporter::Reporter,
-    Configuration, Locator, LocatorKind, LocatorResult,
+    Configuration, Locator, LocatorKind, LocatorResult, RefreshStatePersistence,
+    RefreshStateSyncScope,
 };
 use pet_virtualenv::is_virtualenv;
 use regex::Regex;
@@ -137,7 +138,6 @@ impl Poetry {
         }
     }
     fn clear(&self) {
-        self.poetry_executable.write().unwrap().take();
         self.search_result.write().unwrap().take();
     }
     pub fn from(environment: &dyn Environment) -> Poetry {
@@ -150,6 +150,34 @@ impl Poetry {
             .write()
             .unwrap()
             .clone_from(&search_result);
+    }
+
+    pub fn merge_search_result_from(&self, source: &Poetry) {
+        let source_search_result = source.search_result.read().unwrap().clone();
+        let Some(source_search_result) = source_search_result else {
+            return;
+        };
+
+        let mut merged = self
+            .search_result
+            .read()
+            .unwrap()
+            .clone()
+            .unwrap_or(LocatorResult {
+                managers: vec![],
+                environments: vec![],
+            });
+        merged.managers.extend(source_search_result.managers);
+        merged.managers.sort();
+        merged.managers.dedup();
+
+        merged
+            .environments
+            .extend(source_search_result.environments);
+        merged.environments.sort();
+        merged.environments.dedup();
+
+        self.search_result.write().unwrap().replace(merged);
     }
 
     fn find_with_cache(&self) -> Option<LocatorResult> {
@@ -226,17 +254,39 @@ impl Locator for Poetry {
     fn get_kind(&self) -> LocatorKind {
         LocatorKind::Poetry
     }
+    fn refresh_state(&self) -> RefreshStatePersistence {
+        RefreshStatePersistence::SyncedDiscoveryState
+    }
+    fn sync_refresh_state_from(&self, source: &dyn Locator, scope: &RefreshStateSyncScope) {
+        let source = source.as_any().downcast_ref::<Poetry>().unwrap_or_else(|| {
+            panic!(
+                "attempted to sync Poetry state from {:?}",
+                source.get_kind()
+            )
+        });
+        match scope {
+            RefreshStateSyncScope::Full => self.sync_search_result_from(source),
+            RefreshStateSyncScope::GlobalFiltered(kind)
+                if self.supported_categories().contains(kind) =>
+            {
+                self.sync_search_result_from(source)
+            }
+            RefreshStateSyncScope::Workspace => self.merge_search_result_from(source),
+            RefreshStateSyncScope::GlobalFiltered(_) => {}
+        }
+    }
     fn configure(&self, config: &Configuration) {
+        let mut ws_dirs = self.workspace_directories.write().unwrap();
+        ws_dirs.clear();
         if let Some(workspace_directories) = &config.workspace_directories {
-            let mut ws_dirs = self.workspace_directories.write().unwrap();
-            ws_dirs.clear();
             if !workspace_directories.is_empty() {
                 ws_dirs.extend(workspace_directories.clone());
             }
         }
-        if let Some(exe) = &config.poetry_executable {
-            self.poetry_executable.write().unwrap().replace(exe.clone());
-        }
+        self.poetry_executable
+            .write()
+            .unwrap()
+            .clone_from(&config.poetry_executable);
     }
 
     fn supported_categories(&self) -> Vec<PythonEnvironmentKind> {
@@ -348,5 +398,92 @@ mod tests {
             result.unwrap().environments[0].name.as_deref(),
             Some("fresh")
         );
+    }
+
+    #[test]
+    fn test_workspace_scope_merges_search_results() {
+        let environment = EnvironmentApi::new();
+        let target = Poetry::from(&environment);
+        let source = Poetry::from(&environment);
+
+        target
+            .search_result
+            .write()
+            .unwrap()
+            .replace(LocatorResult {
+                managers: vec![],
+                environments: vec![PythonEnvironment {
+                    name: Some("existing".to_string()),
+                    kind: Some(PythonEnvironmentKind::Poetry),
+                    ..Default::default()
+                }],
+            });
+
+        source
+            .search_result
+            .write()
+            .unwrap()
+            .replace(LocatorResult {
+                managers: vec![],
+                environments: vec![PythonEnvironment {
+                    name: Some("workspace".to_string()),
+                    kind: Some(PythonEnvironmentKind::Poetry),
+                    ..Default::default()
+                }],
+            });
+
+        target.sync_refresh_state_from(&source, &RefreshStateSyncScope::Workspace);
+
+        let result = target.search_result.read().unwrap().clone().unwrap();
+        let mut names = result
+            .environments
+            .iter()
+            .map(|environment| environment.name.clone().unwrap())
+            .collect::<Vec<String>>();
+        names.sort();
+
+        assert_eq!(names, vec!["existing".to_string(), "workspace".to_string()]);
+    }
+
+    #[test]
+    fn test_clear_preserves_configured_poetry_executable() {
+        let environment = EnvironmentApi::new();
+        let poetry = Poetry::from(&environment);
+        let configured = PathBuf::from("/configured/poetry");
+
+        poetry.configure(&Configuration {
+            poetry_executable: Some(configured.clone()),
+            ..Default::default()
+        });
+        poetry
+            .search_result
+            .write()
+            .unwrap()
+            .replace(LocatorResult {
+                managers: vec![],
+                environments: vec![],
+            });
+
+        poetry.clear();
+
+        assert_eq!(
+            poetry.poetry_executable.read().unwrap().clone(),
+            Some(configured)
+        );
+        assert!(poetry.search_result.read().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_configure_clears_poetry_executable_when_unset() {
+        let environment = EnvironmentApi::new();
+        let poetry = Poetry::from(&environment);
+
+        poetry.configure(&Configuration {
+            poetry_executable: Some(PathBuf::from("/configured/poetry")),
+            ..Default::default()
+        });
+        poetry.configure(&Configuration::default());
+
+        assert!(poetry.poetry_executable.read().unwrap().is_none());
     }
 }

--- a/crates/pet-pyenv/src/lib.rs
+++ b/crates/pet-pyenv/src/lib.rs
@@ -19,7 +19,7 @@ use pet_core::{
     os_environment::Environment,
     python_environment::{PythonEnvironment, PythonEnvironmentKind},
     reporter::Reporter,
-    Locator, LocatorKind,
+    Locator, LocatorKind, RefreshStatePersistence,
 };
 use pet_python_utils::executable::find_executable;
 
@@ -83,6 +83,9 @@ impl PyEnv {
 impl Locator for PyEnv {
     fn get_kind(&self) -> LocatorKind {
         LocatorKind::PyEnv
+    }
+    fn refresh_state(&self) -> RefreshStatePersistence {
+        RefreshStatePersistence::SelfHydratingCache
     }
     fn supported_categories(&self) -> Vec<PythonEnvironmentKind> {
         vec![

--- a/crates/pet-pyenv/tests/pyenv_test.rs
+++ b/crates/pet-pyenv/tests/pyenv_test.rs
@@ -546,3 +546,45 @@ fn resolve_pyenv_environment() {
     assert!(result.is_some());
     assert_eq!(result.unwrap().kind, Some(PythonEnvironmentKind::Conda));
 }
+
+#[test]
+#[cfg(unix)]
+fn pyenv_refresh_state_self_hydrates_without_sync() {
+    use crate::common::create_test_environment;
+    use common::resolve_test_path;
+    use pet_conda::Conda;
+    use pet_core::{
+        env::PythonEnv, python_environment::PythonEnvironmentKind, Locator, RefreshStatePersistence,
+    };
+    use pet_pyenv::PyEnv;
+    use pet_reporter::{cache::CacheReporter, collect};
+    use std::{collections::HashMap, sync::Arc};
+
+    let home = resolve_test_path(&["unix", "pyenv", "user_home"]);
+    let homebrew_bin = resolve_test_path(&["unix", "pyenv", "home", "opt", "homebrew", "bin"]);
+    let environment =
+        create_test_environment(HashMap::new(), Some(home.clone()), vec![homebrew_bin], None);
+
+    let shared_conda = Arc::new(Conda::from(&environment));
+    let shared = PyEnv::from(&environment, shared_conda.clone());
+    let refreshed = PyEnv::from(&environment, shared_conda);
+
+    assert_eq!(
+        shared.refresh_state(),
+        RefreshStatePersistence::SelfHydratingCache
+    );
+
+    let reporter = Arc::new(collect::create_reporter());
+    refreshed.find(&CacheReporter::new(reporter));
+
+    let executable =
+        resolve_test_path(&[home.to_str().unwrap(), ".pyenv/versions/3.9.9/bin/python"]);
+    let prefix = resolve_test_path(&[home.to_str().unwrap(), ".pyenv/versions/3.9.9"]);
+
+    let resolved = shared.try_from(&PythonEnv::new(executable, Some(prefix.clone()), None));
+
+    assert!(resolved.is_some());
+    let resolved = resolved.unwrap();
+    assert_eq!(resolved.kind, Some(PythonEnvironmentKind::Pyenv));
+    assert_eq!(resolved.prefix, Some(prefix));
+}

--- a/crates/pet-uv/src/lib.rs
+++ b/crates/pet-uv/src/lib.rs
@@ -12,7 +12,7 @@ use pet_core::{
     python_environment::{PythonEnvironment, PythonEnvironmentBuilder, PythonEnvironmentKind},
     pyvenv_cfg::PyVenvCfg,
     reporter::Reporter,
-    Configuration, Locator, LocatorKind,
+    Configuration, Locator, LocatorKind, RefreshStatePersistence,
 };
 use pet_fs::path::norm_case;
 use pet_python_utils::executable::{find_executable, find_executables};
@@ -85,6 +85,10 @@ impl Locator for Uv {
         LocatorKind::Uv
     }
 
+    fn refresh_state(&self) -> RefreshStatePersistence {
+        RefreshStatePersistence::ConfiguredOnly
+    }
+
     fn supported_categories(&self) -> Vec<PythonEnvironmentKind> {
         vec![
             PythonEnvironmentKind::Uv,
@@ -93,12 +97,12 @@ impl Locator for Uv {
     }
 
     fn configure(&self, config: &Configuration) {
+        let mut ws = self
+            .workspace_directories
+            .lock()
+            .expect("workspace_directories mutex poisoned");
+        ws.clear();
         if let Some(workspace_directories) = config.workspace_directories.as_ref() {
-            let mut ws = self
-                .workspace_directories
-                .lock()
-                .expect("workspace_directories mutex poisoned");
-            ws.clear();
             ws.extend(workspace_directories.iter().cloned());
         }
     }

--- a/crates/pet-windows-registry/src/lib.rs
+++ b/crates/pet-windows-registry/src/lib.rs
@@ -8,7 +8,7 @@ use pet_core::{
     env::PythonEnv,
     python_environment::{PythonEnvironment, PythonEnvironmentKind},
     reporter::Reporter,
-    Locator, LocatorKind, LocatorResult,
+    Locator, LocatorKind, LocatorResult, RefreshStatePersistence, RefreshStateSyncScope,
 };
 use pet_virtualenv::is_virtualenv;
 use std::sync::{Arc, Mutex};
@@ -52,11 +52,47 @@ impl WindowsRegistry {
             .expect("search_result mutex poisoned");
         search_result.take();
     }
+
+    fn sync_search_result_from(&self, source: &WindowsRegistry) {
+        let search_result = source
+            .search_result
+            .lock()
+            .expect("search_result mutex poisoned")
+            .clone();
+        self.search_result
+            .lock()
+            .expect("search_result mutex poisoned")
+            .clone_from(&search_result);
+    }
 }
 
 impl Locator for WindowsRegistry {
     fn get_kind(&self) -> LocatorKind {
         LocatorKind::WindowsRegistry
+    }
+    fn refresh_state(&self) -> RefreshStatePersistence {
+        RefreshStatePersistence::SyncedDiscoveryState
+    }
+    fn sync_refresh_state_from(&self, source: &dyn Locator, scope: &RefreshStateSyncScope) {
+        let source = source
+            .as_any()
+            .downcast_ref::<WindowsRegistry>()
+            .unwrap_or_else(|| {
+                panic!(
+                    "attempted to sync WindowsRegistry state from {:?}",
+                    source.get_kind()
+                )
+            });
+
+        match scope {
+            RefreshStateSyncScope::Full => self.sync_search_result_from(source),
+            RefreshStateSyncScope::GlobalFiltered(kind)
+                if self.supported_categories().contains(kind) =>
+            {
+                self.sync_search_result_from(source)
+            }
+            RefreshStateSyncScope::GlobalFiltered(_) | RefreshStateSyncScope::Workspace => {}
+        }
     }
     fn supported_categories(&self) -> Vec<PythonEnvironmentKind> {
         vec![
@@ -102,5 +138,74 @@ impl Locator for WindowsRegistry {
     #[cfg(unix)]
     fn find(&self, _reporter: &dyn Reporter) {
         //
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pet_conda::Conda;
+    use pet_core::os_environment::EnvironmentApi;
+
+    #[test]
+    fn test_full_refresh_sync_replaces_registry_cache() {
+        let environment = EnvironmentApi::new();
+        let shared = WindowsRegistry::from(Arc::new(Conda::from(&environment)));
+        let refreshed = WindowsRegistry::from(Arc::new(Conda::from(&environment)));
+
+        shared.search_result.lock().unwrap().replace(LocatorResult {
+            managers: vec![],
+            environments: vec![PythonEnvironment {
+                name: Some("stale".to_string()),
+                ..Default::default()
+            }],
+        });
+        refreshed
+            .search_result
+            .lock()
+            .unwrap()
+            .replace(LocatorResult {
+                managers: vec![],
+                environments: vec![PythonEnvironment {
+                    name: Some("fresh".to_string()),
+                    ..Default::default()
+                }],
+            });
+
+        shared.sync_refresh_state_from(&refreshed, &RefreshStateSyncScope::Full);
+
+        let result = shared.search_result.lock().unwrap().clone().unwrap();
+        assert_eq!(result.environments[0].name.as_deref(), Some("fresh"));
+    }
+
+    #[test]
+    fn test_workspace_scope_does_not_replace_registry_cache() {
+        let environment = EnvironmentApi::new();
+        let shared = WindowsRegistry::from(Arc::new(Conda::from(&environment)));
+        let refreshed = WindowsRegistry::from(Arc::new(Conda::from(&environment)));
+
+        shared.search_result.lock().unwrap().replace(LocatorResult {
+            managers: vec![],
+            environments: vec![PythonEnvironment {
+                name: Some("stale".to_string()),
+                ..Default::default()
+            }],
+        });
+        refreshed
+            .search_result
+            .lock()
+            .unwrap()
+            .replace(LocatorResult {
+                managers: vec![],
+                environments: vec![PythonEnvironment {
+                    name: Some("fresh".to_string()),
+                    ..Default::default()
+                }],
+            });
+
+        shared.sync_refresh_state_from(&refreshed, &RefreshStateSyncScope::Workspace);
+
+        let result = shared.search_result.lock().unwrap().clone().unwrap();
+        assert_eq!(result.environments[0].name.as_deref(), Some("stale"));
     }
 }

--- a/crates/pet-windows-store/src/lib.rs
+++ b/crates/pet-windows-store/src/lib.rs
@@ -12,7 +12,9 @@ use pet_core::env::PythonEnv;
 use pet_core::python_environment::{PythonEnvironment, PythonEnvironmentKind};
 use pet_core::reporter::Reporter;
 use pet_core::LocatorKind;
-use pet_core::{os_environment::Environment, Locator};
+use pet_core::{
+    os_environment::Environment, Locator, RefreshStatePersistence, RefreshStateSyncScope,
+};
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 
@@ -52,11 +54,40 @@ impl WindowsStore {
     fn clear(&self) {
         self.environments.write().unwrap().take();
     }
+
+    fn sync_environments_from(&self, source: &WindowsStore) {
+        let environments = source.environments.read().unwrap().clone();
+        self.environments.write().unwrap().clone_from(&environments);
+    }
 }
 
 impl Locator for WindowsStore {
     fn get_kind(&self) -> LocatorKind {
         LocatorKind::WindowsStore
+    }
+    fn refresh_state(&self) -> RefreshStatePersistence {
+        RefreshStatePersistence::SyncedDiscoveryState
+    }
+    fn sync_refresh_state_from(&self, source: &dyn Locator, scope: &RefreshStateSyncScope) {
+        let source = source
+            .as_any()
+            .downcast_ref::<WindowsStore>()
+            .unwrap_or_else(|| {
+                panic!(
+                    "attempted to sync WindowsStore state from {:?}",
+                    source.get_kind()
+                )
+            });
+
+        match scope {
+            RefreshStateSyncScope::Full => self.sync_environments_from(source),
+            RefreshStateSyncScope::GlobalFiltered(kind)
+                if self.supported_categories().contains(kind) =>
+            {
+                self.sync_environments_from(source)
+            }
+            RefreshStateSyncScope::GlobalFiltered(_) | RefreshStateSyncScope::Workspace => {}
+        }
     }
     fn supported_categories(&self) -> Vec<PythonEnvironmentKind> {
         vec![PythonEnvironmentKind::WindowsStore]
@@ -139,5 +170,69 @@ impl Locator for WindowsStore {
     #[cfg(unix)]
     fn find(&self, _reporter: &dyn Reporter) {
         //
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pet_core::os_environment::EnvironmentApi;
+
+    #[test]
+    fn test_full_refresh_sync_replaces_store_cache() {
+        let environment = EnvironmentApi::new();
+        let shared = WindowsStore::from(&environment);
+        let refreshed = WindowsStore::from(&environment);
+
+        shared
+            .environments
+            .write()
+            .unwrap()
+            .replace(vec![PythonEnvironment {
+                name: Some("stale".to_string()),
+                ..Default::default()
+            }]);
+        refreshed
+            .environments
+            .write()
+            .unwrap()
+            .replace(vec![PythonEnvironment {
+                name: Some("fresh".to_string()),
+                ..Default::default()
+            }]);
+
+        shared.sync_refresh_state_from(&refreshed, &RefreshStateSyncScope::Full);
+
+        let result = shared.environments.read().unwrap().clone().unwrap();
+        assert_eq!(result[0].name.as_deref(), Some("fresh"));
+    }
+
+    #[test]
+    fn test_workspace_scope_does_not_replace_store_cache() {
+        let environment = EnvironmentApi::new();
+        let shared = WindowsStore::from(&environment);
+        let refreshed = WindowsStore::from(&environment);
+
+        shared
+            .environments
+            .write()
+            .unwrap()
+            .replace(vec![PythonEnvironment {
+                name: Some("stale".to_string()),
+                ..Default::default()
+            }]);
+        refreshed
+            .environments
+            .write()
+            .unwrap()
+            .replace(vec![PythonEnvironment {
+                name: Some("fresh".to_string()),
+                ..Default::default()
+            }]);
+
+        shared.sync_refresh_state_from(&refreshed, &RefreshStateSyncScope::Workspace);
+
+        let result = shared.environments.read().unwrap().clone().unwrap();
+        assert_eq!(result[0].name.as_deref(), Some("stale"));
     }
 }

--- a/crates/pet/src/jsonrpc.rs
+++ b/crates/pet/src/jsonrpc.rs
@@ -18,7 +18,7 @@ use pet_core::telemetry::TelemetryEvent;
 use pet_core::{
     os_environment::{Environment, EnvironmentApi},
     reporter::Reporter,
-    Configuration, Locator,
+    Configuration, Locator, RefreshStatePersistence, RefreshStateSyncScope,
 };
 use pet_env_var_path::get_search_paths_from_env_variables;
 use pet_fs::glob::expand_glob_patterns;
@@ -316,7 +316,6 @@ pub struct Context {
     configuration: RwLock<ConfigurationState>,
     locators: Arc<Vec<Arc<dyn Locator>>>,
     conda_locator: Arc<Conda>,
-    poetry_locator: Arc<Poetry>,
     os_environment: Arc<dyn Environment>,
     refresh_coordinator: RefreshCoordinator,
 }
@@ -336,7 +335,6 @@ pub fn start_jsonrpc_server() {
     let context = Context {
         locators: create_locators(conda_locator.clone(), poetry_locator.clone(), &environment),
         conda_locator,
-        poetry_locator,
         configuration: RwLock::new(ConfigurationState::default()),
         os_environment: Arc::new(environment),
         refresh_coordinator: RefreshCoordinator::default(),
@@ -522,23 +520,44 @@ fn create_refresh_locators(environment: &dyn Environment) -> RefreshLocators {
     }
 }
 
-fn sync_conda_locator_state(target: &Conda, source: &Conda) {
-    target.environments.clear();
-    target
-        .environments
-        .insert_many(source.environments.clone_map());
+fn sync_refresh_locator_state(
+    target_locators: &[Arc<dyn Locator>],
+    source_locators: &[Arc<dyn Locator>],
+    search_scope: Option<&SearchScope>,
+) {
+    let sync_scope = refresh_state_sync_scope(search_scope);
 
-    target.managers.clear();
-    target.managers.insert_many(source.managers.clone_map());
+    assert_eq!(
+        target_locators.len(),
+        source_locators.len(),
+        "refresh locator graphs drifted"
+    );
 
-    target.mamba_managers.clear();
-    target
-        .mamba_managers
-        .insert_many(source.mamba_managers.clone_map());
+    for (target, source) in target_locators.iter().zip(source_locators.iter()) {
+        assert_eq!(
+            target.get_kind(),
+            source.get_kind(),
+            "refresh locator order drifted"
+        );
+
+        if !matches!(target.refresh_state(), RefreshStatePersistence::Stateless) {
+            trace!(
+                "Applying refresh state contract for locator {:?}: {:?}",
+                target.get_kind(),
+                target.refresh_state()
+            );
+        }
+
+        target.sync_refresh_state_from(source.as_ref(), &sync_scope);
+    }
 }
 
-fn sync_poetry_locator_state(target: &Poetry, source: &Poetry) {
-    target.sync_search_result_from(source);
+fn refresh_state_sync_scope(search_scope: Option<&SearchScope>) -> RefreshStateSyncScope {
+    match search_scope {
+        Some(SearchScope::Workspace) => RefreshStateSyncScope::Workspace,
+        Some(SearchScope::Global(kind)) => RefreshStateSyncScope::GlobalFiltered(*kind),
+        None => RefreshStateSyncScope::Full,
+    }
 }
 
 fn execute_refresh(
@@ -577,7 +596,7 @@ fn execute_refresh(
         config,
         &refresh_locators.locators,
         context.os_environment.deref(),
-        search_scope,
+        search_scope.clone(),
     );
     let summary = summary.lock().expect("summary mutex poisoned");
     for locator in summary.locators.iter() {
@@ -588,15 +607,12 @@ fn execute_refresh(
     }
     trace!("Finished refreshing environments in {:?}", summary.total);
 
-    // Refresh runs on a transient locator graph, so copy back any discovery state
-    // that later JSONRPC requests rely on from the long-lived shared locators.
-    sync_conda_locator_state(
-        context.conda_locator.as_ref(),
-        refresh_locators.conda_locator.as_ref(),
-    );
-    sync_poetry_locator_state(
-        context.poetry_locator.as_ref(),
-        refresh_locators.poetry_locator.as_ref(),
+    // Refresh runs on a transient locator graph, so apply each locator's refresh-state
+    // contract back into the long-lived shared locator graph.
+    sync_refresh_locator_state(
+        context.locators.as_ref(),
+        refresh_locators.locators.as_ref(),
+        search_scope.as_ref(),
     );
 
     let perf = RefreshPerformance {
@@ -946,6 +962,7 @@ mod tests {
     use super::*;
     use pet_conda::manager::CondaManager;
     use pet_core::manager::EnvManagerType;
+    use pet_core::RefreshStatePersistence;
     use std::path::PathBuf;
     use std::sync::mpsc;
     use std::thread;
@@ -1057,7 +1074,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sync_conda_locator_state_replaces_shared_caches() {
+    fn test_conda_refresh_state_sync_replaces_shared_caches() {
         let environment = EnvironmentApi::new();
         let shared = Conda::from(&environment);
         let refreshed = Conda::from(&environment);
@@ -1127,7 +1144,12 @@ mod tests {
             },
         );
 
-        sync_conda_locator_state(&shared, &refreshed);
+        assert_eq!(
+            shared.refresh_state(),
+            RefreshStatePersistence::SyncedDiscoveryState
+        );
+
+        shared.sync_refresh_state_from(&refreshed, &RefreshStateSyncScope::Full);
 
         assert_eq!(shared.environments.len(), 1);
         assert!(!shared.environments.contains_key(&stale_env_path));
@@ -1140,6 +1162,88 @@ mod tests {
         assert_eq!(shared.mamba_managers.len(), 1);
         assert!(!shared.mamba_managers.contains_key(&stale_mamba_path));
         assert!(shared.mamba_managers.contains_key(&fresh_mamba_path));
+    }
+
+    #[test]
+    fn test_workspace_refresh_does_not_replace_shared_conda_state() {
+        let environment = EnvironmentApi::new();
+        let shared = Arc::new(Conda::from(&environment));
+        let refreshed = Arc::new(Conda::from(&environment));
+
+        let stale_env_path = PathBuf::from("/stale/env");
+        let fresh_env_path = PathBuf::from("/fresh/env");
+
+        shared.environments.insert(
+            stale_env_path.clone(),
+            PythonEnvironment::new(
+                Some(stale_env_path.join("python")),
+                Some(PythonEnvironmentKind::Conda),
+                Some(stale_env_path.clone()),
+                None,
+                Some("3.10.0".to_string()),
+            ),
+        );
+        refreshed.environments.insert(
+            fresh_env_path.clone(),
+            PythonEnvironment::new(
+                Some(fresh_env_path.join("python")),
+                Some(PythonEnvironmentKind::Conda),
+                Some(fresh_env_path.clone()),
+                None,
+                Some("3.11.0".to_string()),
+            ),
+        );
+
+        sync_refresh_locator_state(
+            &[shared.clone() as Arc<dyn Locator>],
+            &[refreshed as Arc<dyn Locator>],
+            Some(&SearchScope::Workspace),
+        );
+
+        assert_eq!(shared.environments.len(), 1);
+        assert!(shared.environments.contains_key(&stale_env_path));
+        assert!(!shared.environments.contains_key(&fresh_env_path));
+    }
+
+    #[test]
+    fn test_kind_filtered_refresh_skips_unrelated_conda_state_sync() {
+        let environment = EnvironmentApi::new();
+        let shared = Arc::new(Conda::from(&environment));
+        let refreshed = Arc::new(Conda::from(&environment));
+
+        let stale_env_path = PathBuf::from("/stale/env");
+        let fresh_env_path = PathBuf::from("/fresh/env");
+
+        shared.environments.insert(
+            stale_env_path.clone(),
+            PythonEnvironment::new(
+                Some(stale_env_path.join("python")),
+                Some(PythonEnvironmentKind::Conda),
+                Some(stale_env_path.clone()),
+                None,
+                Some("3.10.0".to_string()),
+            ),
+        );
+        refreshed.environments.insert(
+            fresh_env_path.clone(),
+            PythonEnvironment::new(
+                Some(fresh_env_path.join("python")),
+                Some(PythonEnvironmentKind::Conda),
+                Some(fresh_env_path.clone()),
+                None,
+                Some("3.11.0".to_string()),
+            ),
+        );
+
+        sync_refresh_locator_state(
+            &[shared.clone() as Arc<dyn Locator>],
+            &[refreshed as Arc<dyn Locator>],
+            Some(&SearchScope::Global(PythonEnvironmentKind::Venv)),
+        );
+
+        assert_eq!(shared.environments.len(), 1);
+        assert!(shared.environments.contains_key(&stale_env_path));
+        assert!(!shared.environments.contains_key(&fresh_env_path));
     }
 
     #[test]


### PR DESCRIPTION
This follow-up to #383 turns the implicit post-refresh state rules into an explicit locator contract so transient refresh graphs do not silently regress later resolve, find, or telemetry behavior.

- add `RefreshStatePersistence` and scope-aware `sync_refresh_state_from()` to the core `Locator` contract
- classify config-only, self-hydrating, and synchronized locators across Conda, Poetry, PyEnv, PipEnv, Uv, Linux global Python, Windows Registry, and Windows Store
- make refresh-state handoff generic in `jsonrpc.rs`, including partial-refresh handling and workspace-scope Poetry merges
- align config-carrying locators with replace semantics so cleared configure inputs do not leave stale executables or workspace directories behind
- add unit coverage for Conda partial-refresh behavior, Poetry workspace merges and configure clearing, PyEnv self-hydration, and Windows Registry/Store sync semantics

Fixes #387