### PR TITLE
test: add reporter jsonrpc coverage

### DIFF
--- a/crates/pet-reporter/src/jsonrpc.rs
+++ b/crates/pet-reporter/src/jsonrpc.rs
@@ -39,21 +39,29 @@ impl Reporter for JsonRpcReporter {
     }
 
     fn report_environment(&self, env: &PythonEnvironment) {
-        if let Some(report_only) = &self.report_only {
-            if env.kind != Some(*report_only) {
-                trace!(
-                    "Skip Reporting Environment ({:?}) {:?} due to refresh request to report only {:?}",
-                    env.kind,
-                    env.executable
-                        .clone()
-                        .unwrap_or(env.prefix.clone().unwrap_or_default()),
-                    report_only
-                );
-                return;
-            }
+        if !should_report_environment(self.report_only, env) {
+            trace!(
+                "Skip Reporting Environment ({:?}) {:?} due to refresh request to report only {:?}",
+                env.kind,
+                env.executable
+                    .clone()
+                    .unwrap_or(env.prefix.clone().unwrap_or_default()),
+                self.report_only
+            );
+            return;
         }
         trace!("Reporting Environment {:?}", env);
         send_message("environment", env.into())
+    }
+}
+
+fn should_report_environment(
+    report_only: Option<PythonEnvironmentKind>,
+    env: &PythonEnvironment,
+) -> bool {
+    match report_only {
+        Some(kind) => env.kind == Some(kind),
+        None => true,
     }
 }
 
@@ -99,4 +107,82 @@ pub fn initialize_logger(log_level: LevelFilter) {
         })
         .filter(None, log_level)
         .init();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pet_core::telemetry::TelemetryEvent;
+    use serde_json::json;
+    use std::{collections::BTreeMap, path::PathBuf};
+
+    fn create_environment(kind: PythonEnvironmentKind) -> PythonEnvironment {
+        PythonEnvironment::new(
+            Some(PathBuf::from("/tmp/.venv/bin/python")),
+            Some(kind),
+            Some(PathBuf::from("/tmp/.venv")),
+            None,
+            Some("3.12.0".to_string()),
+        )
+    }
+
+    #[test]
+    fn environment_filter_allows_all_without_requested_kind() {
+        let environment = create_environment(PythonEnvironmentKind::Venv);
+
+        assert!(should_report_environment(None, &environment));
+    }
+
+    #[test]
+    fn environment_filter_allows_matching_requested_kind() {
+        let environment = create_environment(PythonEnvironmentKind::Poetry);
+
+        assert!(should_report_environment(
+            Some(PythonEnvironmentKind::Poetry),
+            &environment
+        ));
+    }
+
+    #[test]
+    fn environment_filter_rejects_non_matching_requested_kind() {
+        let environment = create_environment(PythonEnvironmentKind::Venv);
+
+        assert!(!should_report_environment(
+            Some(PythonEnvironmentKind::Poetry),
+            &environment
+        ));
+    }
+
+    #[test]
+    fn telemetry_data_serializes_event_name_and_payload() {
+        let event = TelemetryEvent::RefreshPerformance(
+            pet_core::telemetry::refresh_performance::RefreshPerformance {
+                total: 10,
+                locators: BTreeMap::new(),
+                breakdown: BTreeMap::new(),
+            },
+        );
+        let payload = TelemetryData {
+            event: get_telemetry_event_name(&event).to_string(),
+            data: event,
+        };
+
+        let value = serde_json::to_value(payload).unwrap();
+
+        assert_eq!(value["event"], json!("RefreshPerformance"));
+        assert_eq!(value["data"]["refreshPerformance"]["total"], json!(10));
+    }
+
+    #[test]
+    fn log_payload_uses_camel_case_fields_and_level_renames() {
+        let payload = Log {
+            message: "hello".to_string(),
+            level: LogLevel::Warning,
+        };
+
+        assert_eq!(
+            serde_json::to_value(payload).unwrap(),
+            json!({ "message": "hello", "level": "warning" })
+        );
+    }
 }


### PR DESCRIPTION
Summary:
- Extract the JSONRPC reporter environment-kind filter into a private helper for direct testing.
- Add tests for filter behavior, telemetry payload serialization, and log payload serialization.
- Covers the `pet-reporter` slice from the #389 coverage plan.

Validation:
- cargo test -p pet-reporter
- cargo fmt --all
- cargo clippy --all -- -D warnings

Refs #389