### PR TITLE
test: add env var path coverage

### DIFF
--- a/crates/pet-env-var-path/src/lib.rs
+++ b/crates/pet-env-var-path/src/lib.rs
@@ -163,4 +163,26 @@ mod tests {
             vec![normalize_search_path(PathBuf::from("/usr/bin"))]
         );
     }
+
+    #[test]
+    fn windows_apps_path_detection_is_case_insensitive_by_components() {
+        let path = PathBuf::from(if cfg!(windows) {
+            r"C:\Users\User\appdata\LOCAL\microsoft\WINDOWSAPPS"
+        } else {
+            "/Users/user/appdata/LOCAL/microsoft/WINDOWSAPPS"
+        });
+
+        assert!(is_windows_apps_path(&path, None));
+    }
+
+    #[test]
+    fn windows_apps_path_detection_rejects_partial_component_matches() {
+        let path = PathBuf::from(if cfg!(windows) {
+            r"C:\Users\User\AppDataBackup\Local\Microsoft\WindowsApps"
+        } else {
+            "/Users/user/AppDataBackup/Local/Microsoft/WindowsApps"
+        });
+
+        assert!(!is_windows_apps_path(&path, None));
+    }
 }


### PR DESCRIPTION
Summary:
- Add coverage for WindowsApps path component matching in `pet-env-var-path`.
- Verify matching is case-insensitive by component and rejects partial component names.
- Covers a small utility-crate slice from the #389 coverage plan.

Validation:
- cargo test -p pet-env-var-path
- cargo fmt --all
- cargo clippy --all -- -D warnings

Refs #389