### PR TITLE
test: add pixi prefix coverage

### DIFF
--- a/crates/pet-pixi/src/lib.rs
+++ b/crates/pet-pixi/src/lib.rs
@@ -193,6 +193,33 @@ mod tests {
     }
 
     #[test]
+    fn try_from_derives_pixi_prefix_from_direct_child_executable() {
+        let temp_dir = TempDir::new().unwrap();
+        let prefix = create_pixi_prefix(&temp_dir);
+        let executable = prefix.join(if cfg!(windows) {
+            "python.exe"
+        } else {
+            "python"
+        });
+        fs::write(&executable, b"").unwrap();
+        let locator = Pixi::new();
+        let env = PythonEnv::new(executable, None, None);
+
+        let pixi_env = locator.try_from(&env).unwrap();
+
+        assert_eq!(pixi_env.kind, Some(PythonEnvironmentKind::Pixi));
+        assert_eq!(
+            pixi_env
+                .prefix
+                .as_deref()
+                .map(fs::canonicalize)
+                .transpose()
+                .unwrap(),
+            Some(fs::canonicalize(prefix).unwrap())
+        );
+    }
+
+    #[test]
     fn try_from_rejects_non_pixi_environments() {
         let temp_dir = TempDir::new().unwrap();
         let executable = temp_dir.path().join("python");


### PR DESCRIPTION
Summary:
- Add coverage for deriving a Pixi prefix from a direct-child Python executable.
- Complements existing explicit-prefix and nested `bin`/`Scripts` executable tests.
- Covers a small utility-crate slice from the #389 coverage plan.

Validation:
- cargo test -p pet-pixi
- cargo fmt --all
- cargo clippy --all -- -D warnings

Refs #389