### PR TITLE
fix: replace broken choco pyenv-win install with official PowerShell installer (Fixes #446)

### DIFF
--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -81,9 +81,7 @@ jobs:
         run: |
           Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1"
           $pyenvBin = "$env:USERPROFILE\.pyenv\pyenv-win\bin"
-          $pyenvShims = "$env:USERPROFILE\.pyenv\pyenv-win\shims"
           echo "$pyenvBin" >> $env:GITHUB_PATH
-          echo "$pyenvShims" >> $env:GITHUB_PATH
           echo "PYENV_ROOT=$env:USERPROFILE\.pyenv" >> $env:GITHUB_ENV
         shell: pwsh
 

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -79,10 +79,13 @@ jobs:
       - name: Install pyenv (Windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          choco install pyenv-win -y
-          echo "PATH=$PATH;$HOME/.pyenv/pyenv-win/bin;$HOME/.pyenv/pyenv-win/shims" >> $GITHUB_ENV
-          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
-        shell: bash
+          Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1"
+          $pyenvBin = "$env:USERPROFILE\.pyenv\pyenv-win\bin"
+          $pyenvShims = "$env:USERPROFILE\.pyenv\pyenv-win\shims"
+          echo "$pyenvBin" >> $env:GITHUB_PATH
+          echo "$pyenvShims" >> $env:GITHUB_PATH
+          echo "PYENV_ROOT=$env:USERPROFILE\.pyenv" >> $env:GITHUB_ENV
+        shell: pwsh
 
       - name: Install pyenv and pyenv-virtualenv (Linux)
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -110,9 +110,7 @@ jobs:
         run: |
           Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1"
           $pyenvBin = "$env:USERPROFILE\.pyenv\pyenv-win\bin"
-          $pyenvShims = "$env:USERPROFILE\.pyenv\pyenv-win\shims"
           echo "$pyenvBin" >> $env:GITHUB_PATH
-          echo "$pyenvShims" >> $env:GITHUB_PATH
           echo "PYENV_ROOT=$env:USERPROFILE\.pyenv" >> $env:GITHUB_ENV
         shell: pwsh
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -108,10 +108,13 @@ jobs:
       - name: Install pyenv (Windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          choco install pyenv-win -y
-          echo "PATH=$PATH;$HOME/.pyenv/pyenv-win/bin;$HOME/.pyenv/pyenv-win/shims" >> $GITHUB_ENV
-          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
-        shell: bash
+          Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1"
+          $pyenvBin = "$env:USERPROFILE\.pyenv\pyenv-win\bin"
+          $pyenvShims = "$env:USERPROFILE\.pyenv\pyenv-win\shims"
+          echo "$pyenvBin" >> $env:GITHUB_PATH
+          echo "$pyenvShims" >> $env:GITHUB_PATH
+          echo "PYENV_ROOT=$env:USERPROFILE\.pyenv" >> $env:GITHUB_ENV
+        shell: pwsh
 
       - name: Install pyenv and pyenv-virtualenv (Linux)
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -110,13 +110,16 @@ jobs:
           echo "WORKON_HOME=$HOME/.virtualenvs" >> $GITHUB_ENV
         shell: bash
 
-      - name: Install pyenv
+      - name: Install pyenv (Windows)
         if: startsWith( matrix.os, 'windows')
         run: |
-          choco install pyenv-win -y
-          echo "PATH=$PATH;$HOME/.pyenv/pyenv-win/bin;$HOME/.pyenv/pyenv-win/shims" >> $GITHUB_ENV
-          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
-        shell: bash
+          Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1"
+          $pyenvBin = "$env:USERPROFILE\.pyenv\pyenv-win\bin"
+          $pyenvShims = "$env:USERPROFILE\.pyenv\pyenv-win\shims"
+          echo "$pyenvBin" >> $env:GITHUB_PATH
+          echo "$pyenvShims" >> $env:GITHUB_PATH
+          echo "PYENV_ROOT=$env:USERPROFILE\.pyenv" >> $env:GITHUB_ENV
+        shell: pwsh
 
       - name: Install pyenv and pyenv-virtualenv
         if: startsWith( matrix.os, 'ubuntu') || startsWith( matrix.os, 'macos')

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -115,9 +115,7 @@ jobs:
         run: |
           Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1"
           $pyenvBin = "$env:USERPROFILE\.pyenv\pyenv-win\bin"
-          $pyenvShims = "$env:USERPROFILE\.pyenv\pyenv-win\shims"
           echo "$pyenvBin" >> $env:GITHUB_PATH
-          echo "$pyenvShims" >> $env:GITHUB_PATH
           echo "PYENV_ROOT=$env:USERPROFILE\.pyenv" >> $env:GITHUB_ENV
         shell: pwsh
 


### PR DESCRIPTION
The \choco install pyenv-win -y\ command in CI is broken, causing all Windows coverage jobs to fail with \pyenv: command not found\.

**Changes:**
- Replace Chocolatey install with official pyenv-win PowerShell installer script
- Use \GITHUB_PATH\ instead of \GITHUB_ENV\ PATH manipulation for proper cross-step PATH persistence
- Switch shell from \ash\ to \pwsh\ for native PowerShell compatibility
- Consistent step naming (\Install pyenv (Windows)\) across all workflows

Fixes #446