### PR TITLE
perf(pet-windows-registry): parallelize HKLM/HKCU walk and reuse cache across refresh

### DIFF
--- a/crates/pet-windows-registry/src/environments.rs
+++ b/crates/pet-windows-registry/src/environments.rs
@@ -31,11 +31,18 @@ fn empty_result() -> LocatorResult {
 /// surface their environments. Without this we'd silently lose the entire
 /// hive when one company's walk panics — exactly the kind of regression
 /// that's hardest to debug after the fact.
+///
+/// Returns `(result, had_panic)` so callers can decide not to cache a
+/// partial result (otherwise a single transient panic would persist as a
+/// stale empty/partial cache across refreshes — see issue #454).
 #[cfg(windows)]
-fn join_or_warn(join_result: std::thread::Result<LocatorResult>, label: &str) -> LocatorResult {
+fn join_or_warn(
+    join_result: std::thread::Result<LocatorResult>,
+    label: &str,
+) -> (LocatorResult, bool) {
     use log::warn;
     match join_result {
-        Ok(result) => result,
+        Ok(result) => (result, false),
         Err(panic_payload) => {
             // Try to render the payload for the log; payloads are commonly
             // either a `&'static str` or a `String`.
@@ -45,16 +52,26 @@ fn join_or_warn(join_result: std::thread::Result<LocatorResult>, label: &str) ->
                 .or_else(|| panic_payload.downcast_ref::<String>().cloned())
                 .unwrap_or_else(|| "<non-string panic payload>".to_string());
             warn!("Registry walk thread for {} panicked: {}", label, message);
-            empty_result()
+            (empty_result(), true)
         }
     }
+}
+
+/// Outcome of a registry walk: the discovered environments/managers and a
+/// flag indicating whether any worker thread panicked. Callers should
+/// avoid caching a result with `had_panic = true` so a transient failure
+/// can be retried on the next refresh instead of becoming sticky.
+#[cfg(windows)]
+pub struct RegistryWalkOutcome {
+    pub result: LocatorResult,
+    pub had_panic: bool,
 }
 
 #[cfg(windows)]
 pub fn get_registry_pythons(
     conda_locator: &Arc<dyn CondaLocator>,
     reporter: &Option<&dyn Reporter>,
-) -> LocatorResult {
+) -> RegistryWalkOutcome {
     use std::thread;
 
     // Walk both hives in parallel. Each hive walks its companies in parallel
@@ -62,7 +79,7 @@ pub fn get_registry_pythons(
     // independent registry trees and Defender intercepts every read, so the
     // serial baseline was paying for both round-trips back to back; the
     // scope-spawn pattern matches `pet-pyenv` / `pet-homebrew` / `pet-conda`.
-    let (hklm_result, hkcu_result) = thread::scope(|s| {
+    let ((hklm_result, hklm_panic), (hkcu_result, hkcu_panic)) = thread::scope(|s| {
         let hklm = s.spawn(|| {
             get_registry_pythons_for_hive(
                 "HKLM",
@@ -80,8 +97,8 @@ pub fn get_registry_pythons(
             )
         });
         (
-            join_or_warn(hklm.join(), "HKLM"),
-            join_or_warn(hkcu.join(), "HKCU"),
+            join_hive_outcome(hklm.join(), "HKLM"),
+            join_hive_outcome(hkcu.join(), "HKCU"),
         )
     });
 
@@ -90,9 +107,35 @@ pub fn get_registry_pythons(
     let mut managers = hklm_result.managers;
     managers.extend(hkcu_result.managers);
 
-    LocatorResult {
-        environments,
-        managers,
+    RegistryWalkOutcome {
+        result: LocatorResult {
+            environments,
+            managers,
+        },
+        had_panic: hklm_panic || hkcu_panic,
+    }
+}
+
+/// Sibling of `join_or_warn` for hive-level threads. Returns the recovered
+/// `LocatorResult` plus a `had_panic` flag that already accounts for any
+/// company-level panics propagated through `RegistryWalkOutcome`.
+#[cfg(windows)]
+fn join_hive_outcome(
+    join_result: std::thread::Result<RegistryWalkOutcome>,
+    label: &str,
+) -> (LocatorResult, bool) {
+    use log::warn;
+    match join_result {
+        Ok(outcome) => (outcome.result, outcome.had_panic),
+        Err(panic_payload) => {
+            let message = panic_payload
+                .downcast_ref::<&'static str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| panic_payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "<non-string panic payload>".to_string());
+            warn!("Registry walk thread for {} panicked: {}", label, message);
+            (empty_result(), true)
+        }
     }
 }
 
@@ -105,7 +148,7 @@ fn get_registry_pythons_for_hive(
     hive: RegKey,
     conda_locator: &Arc<dyn CondaLocator>,
     reporter: &Option<&dyn Reporter>,
-) -> LocatorResult {
+) -> RegistryWalkOutcome {
     use log::{trace, warn};
     use std::thread;
 
@@ -113,7 +156,10 @@ fn get_registry_pythons_for_hive(
         Ok(k) => k,
         Err(err) => {
             warn!("Failed to open {}\\Software\\Python, {:?}", name, err);
-            return empty_result();
+            return RegistryWalkOutcome {
+                result: empty_result(),
+                had_panic: false,
+            };
         }
     };
 
@@ -137,7 +183,7 @@ fn get_registry_pythons_for_hive(
         })
         .collect();
 
-    let results: Vec<LocatorResult> = thread::scope(|s| {
+    let results: Vec<(LocatorResult, bool)> = thread::scope(|s| {
         let handles: Vec<_> = companies
             .into_iter()
             .map(|(company, company_key)| {
@@ -168,13 +214,18 @@ fn get_registry_pythons_for_hive(
 
     let mut environments = vec![];
     let mut managers = vec![];
-    for r in results {
+    let mut had_panic = false;
+    for (r, panicked) in results {
         environments.extend(r.environments);
         managers.extend(r.managers);
+        had_panic |= panicked;
     }
-    LocatorResult {
-        environments,
-        managers,
+    RegistryWalkOutcome {
+        result: LocatorResult {
+            environments,
+            managers,
+        },
+        had_panic,
     }
 }
 

--- a/crates/pet-windows-registry/src/environments.rs
+++ b/crates/pet-windows-registry/src/environments.rs
@@ -8,7 +8,6 @@ use pet_core::reporter::Reporter;
 #[cfg(windows)]
 use pet_core::{
     arch::Architecture,
-    manager::EnvManager,
     python_environment::{PythonEnvironmentBuilder, PythonEnvironmentKind},
     LocatorResult,
 };
@@ -20,59 +19,154 @@ use std::{path::PathBuf, sync::Arc};
 use winreg::RegKey;
 
 #[cfg(windows)]
+fn empty_result() -> LocatorResult {
+    LocatorResult {
+        environments: vec![],
+        managers: vec![],
+    }
+}
+
+/// Logs a warning if a spawned registry-walk thread panicked, then
+/// substitutes an empty result so the surviving hive/companies still
+/// surface their environments. Without this we'd silently lose the entire
+/// hive when one company's walk panics — exactly the kind of regression
+/// that's hardest to debug after the fact.
+#[cfg(windows)]
+fn join_or_warn(join_result: std::thread::Result<LocatorResult>, label: &str) -> LocatorResult {
+    use log::warn;
+    match join_result {
+        Ok(result) => result,
+        Err(panic_payload) => {
+            // Try to render the payload for the log; payloads are commonly
+            // either a `&'static str` or a `String`.
+            let message = panic_payload
+                .downcast_ref::<&'static str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| panic_payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "<non-string panic payload>".to_string());
+            warn!("Registry walk thread for {} panicked: {}", label, message);
+            empty_result()
+        }
+    }
+}
+
+#[cfg(windows)]
 pub fn get_registry_pythons(
     conda_locator: &Arc<dyn CondaLocator>,
     reporter: &Option<&dyn Reporter>,
 ) -> LocatorResult {
+    use std::thread;
+
+    // Walk both hives in parallel. Each hive walks its companies in parallel
+    // too (see `get_registry_pythons_for_hive`). HKLM and HKCU sit on
+    // independent registry trees and Defender intercepts every read, so the
+    // serial baseline was paying for both round-trips back to back; the
+    // scope-spawn pattern matches `pet-pyenv` / `pet-homebrew` / `pet-conda`.
+    let (hklm_result, hkcu_result) = thread::scope(|s| {
+        let hklm = s.spawn(|| {
+            get_registry_pythons_for_hive(
+                "HKLM",
+                RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE),
+                conda_locator,
+                reporter,
+            )
+        });
+        let hkcu = s.spawn(|| {
+            get_registry_pythons_for_hive(
+                "HKCU",
+                RegKey::predef(winreg::enums::HKEY_CURRENT_USER),
+                conda_locator,
+                reporter,
+            )
+        });
+        (
+            join_or_warn(hklm.join(), "HKLM"),
+            join_or_warn(hkcu.join(), "HKCU"),
+        )
+    });
+
+    let mut environments = hklm_result.environments;
+    environments.extend(hkcu_result.environments);
+    let mut managers = hklm_result.managers;
+    managers.extend(hkcu_result.managers);
+
+    LocatorResult {
+        environments,
+        managers,
+    }
+}
+
+/// Walks `<hive>\Software\Python\<company>` for every company in the given
+/// hive. Companies are processed in parallel; each spawned thread owns its
+/// own `RegKey` handle (which is `Send` but not `Sync` in `winreg`).
+#[cfg(windows)]
+fn get_registry_pythons_for_hive(
+    name: &'static str,
+    hive: RegKey,
+    conda_locator: &Arc<dyn CondaLocator>,
+    reporter: &Option<&dyn Reporter>,
+) -> LocatorResult {
     use log::{trace, warn};
+    use std::thread;
+
+    let python_key = match hive.open_subkey("Software\\Python") {
+        Ok(k) => k,
+        Err(err) => {
+            warn!("Failed to open {}\\Software\\Python, {:?}", name, err);
+            return empty_result();
+        }
+    };
+
+    // Open each company subkey serially. Opening a registry handle is cheap
+    // (no recursive enumeration); the heavy work happens once we start
+    // pulling values out of `<company>\<install>\InstallPath`. Collecting
+    // owned `(String, RegKey)` pairs lets us hand each company to its own
+    // thread without sharing a `RegKey` (which is `Send` but not `Sync`).
+    let companies: Vec<(String, RegKey)> = python_key
+        .enum_keys()
+        .filter_map(Result::ok)
+        .filter_map(|company| match python_key.open_subkey(&company) {
+            Ok(company_key) => Some((company, company_key)),
+            Err(err) => {
+                warn!(
+                    "Failed to open {}\\Software\\Python\\{}, {:?}",
+                    name, company, err
+                );
+                None
+            }
+        })
+        .collect();
+
+    let results: Vec<LocatorResult> = thread::scope(|s| {
+        let handles: Vec<_> = companies
+            .into_iter()
+            .map(|(company, company_key)| {
+                s.spawn(move || {
+                    // Trace order is intentionally relaxed: companies are
+                    // walked in parallel, so this line interleaves with the
+                    // others from the same hive.
+                    trace!("Searching {}\\Software\\Python\\{}", name, company);
+                    get_registry_pythons_from_key_for_company(
+                        name,
+                        &company_key,
+                        &company,
+                        conda_locator,
+                        reporter,
+                    )
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| join_or_warn(h.join(), "per-company walk"))
+            .collect()
+    });
 
     let mut environments = vec![];
-    let mut managers: Vec<EnvManager> = vec![];
-
-    struct RegistryKey {
-        pub name: &'static str,
-        pub key: winreg::RegKey,
-    }
-    let search_keys = [
-        RegistryKey {
-            name: "HKLM",
-            key: winreg::RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE),
-        },
-        RegistryKey {
-            name: "HKCU",
-            key: winreg::RegKey::predef(winreg::enums::HKEY_CURRENT_USER),
-        },
-    ];
-    for (name, key) in search_keys.iter().map(|f| (f.name, &f.key)) {
-        match key.open_subkey("Software\\Python") {
-            Ok(python_key) => {
-                for company in python_key.enum_keys().filter_map(Result::ok) {
-                    trace!("Searching {}\\Software\\Python\\{}", name, company);
-                    match python_key.open_subkey(&company) {
-                        Ok(company_key) => {
-                            let result = get_registry_pythons_from_key_for_company(
-                                name,
-                                &company_key,
-                                &company,
-                                conda_locator,
-                                reporter,
-                            );
-                            managers.extend(result.managers);
-                            environments.extend(result.environments);
-                        }
-                        Err(err) => {
-                            warn!(
-                                "Failed to open {}\\Software\\Python\\{}, {:?}",
-                                name, company, err
-                            );
-                        }
-                    }
-                }
-            }
-            Err(err) => {
-                warn!("Failed to open {}\\Software\\Python, {:?}", name, err)
-            }
-        }
+    let mut managers = vec![];
+    for r in results {
+        environments.extend(r.environments);
+        managers.extend(r.managers);
     }
     LocatorResult {
         environments,

--- a/crates/pet-windows-registry/src/environments.rs
+++ b/crates/pet-windows-registry/src/environments.rs
@@ -142,8 +142,7 @@ fn get_registry_pythons_for_hive(
             .into_iter()
             .map(|(company, company_key)| {
                 // Build the panic-warning label up-front so a panicking
-                // company thread is identifiable in logs (issue #454
-                // Copilot review feedback).
+                // company thread is identifiable in logs (issue #454).
                 let label = format!("{name}\\Software\\Python\\{company}");
                 let handle = s.spawn(move || {
                     // Trace order is intentionally relaxed: companies are

--- a/crates/pet-windows-registry/src/environments.rs
+++ b/crates/pet-windows-registry/src/environments.rs
@@ -26,23 +26,45 @@ fn empty_result() -> LocatorResult {
     }
 }
 
+/// What a single company-level worker thread produces: the registry-derived
+/// `PythonEnvironment`s plus the install dirs that turned out to be conda
+/// roots. We capture conda dirs (instead of just calling
+/// `conda_locator.find_and_report` and forgetting) so that subsequent
+/// `find()` calls on a cache hit can replay them — otherwise registry-only
+/// conda installs would silently disappear after the first refresh.
+#[cfg(windows)]
+struct CompanyWalkOutcome {
+    result: LocatorResult,
+    conda_install_dirs: Vec<PathBuf>,
+}
+
+#[cfg(windows)]
+impl CompanyWalkOutcome {
+    fn empty() -> Self {
+        Self {
+            result: empty_result(),
+            conda_install_dirs: vec![],
+        }
+    }
+}
+
 /// Logs a warning if a spawned registry-walk thread panicked, then
-/// substitutes an empty result so the surviving hive/companies still
+/// substitutes an empty outcome so the surviving hive/companies still
 /// surface their environments. Without this we'd silently lose the entire
 /// hive when one company's walk panics — exactly the kind of regression
 /// that's hardest to debug after the fact.
 ///
-/// Returns `(result, had_panic)` so callers can decide not to cache a
+/// Returns `(outcome, had_panic)` so callers can decide not to cache a
 /// partial result (otherwise a single transient panic would persist as a
 /// stale empty/partial cache across refreshes — see issue #454).
 #[cfg(windows)]
 fn join_or_warn(
-    join_result: std::thread::Result<LocatorResult>,
+    join_result: std::thread::Result<CompanyWalkOutcome>,
     label: &str,
-) -> (LocatorResult, bool) {
+) -> (CompanyWalkOutcome, bool) {
     use log::warn;
     match join_result {
-        Ok(result) => (result, false),
+        Ok(outcome) => (outcome, false),
         Err(panic_payload) => {
             // Try to render the payload for the log; payloads are commonly
             // either a `&'static str` or a `String`.
@@ -52,18 +74,21 @@ fn join_or_warn(
                 .or_else(|| panic_payload.downcast_ref::<String>().cloned())
                 .unwrap_or_else(|| "<non-string panic payload>".to_string());
             warn!("Registry walk thread for {} panicked: {}", label, message);
-            (empty_result(), true)
+            (CompanyWalkOutcome::empty(), true)
         }
     }
 }
 
-/// Outcome of a registry walk: the discovered environments/managers and a
-/// flag indicating whether any worker thread panicked. Callers should
-/// avoid caching a result with `had_panic = true` so a transient failure
-/// can be retried on the next refresh instead of becoming sticky.
+/// Outcome of a registry walk: the discovered environments/managers, the
+/// conda install dirs found via the registry (so cache-hit replays can
+/// re-invoke `conda_locator.find_and_report`), and a flag indicating
+/// whether any worker thread panicked. Callers should avoid caching a
+/// result with `had_panic = true` so a transient failure can be retried
+/// on the next refresh instead of becoming sticky.
 #[cfg(windows)]
 pub struct RegistryWalkOutcome {
     pub result: LocatorResult,
+    pub conda_install_dirs: Vec<PathBuf>,
     pub had_panic: bool,
 }
 
@@ -79,7 +104,7 @@ pub fn get_registry_pythons(
     // independent registry trees and Defender intercepts every read, so the
     // serial baseline was paying for both round-trips back to back; the
     // scope-spawn pattern matches `pet-pyenv` / `pet-homebrew` / `pet-conda`.
-    let ((hklm_result, hklm_panic), (hkcu_result, hkcu_panic)) = thread::scope(|s| {
+    let (hklm_outcome, hkcu_outcome) = thread::scope(|s| {
         let hklm = s.spawn(|| {
             get_registry_pythons_for_hive(
                 "HKLM",
@@ -102,31 +127,34 @@ pub fn get_registry_pythons(
         )
     });
 
-    let mut environments = hklm_result.environments;
-    environments.extend(hkcu_result.environments);
-    let mut managers = hklm_result.managers;
-    managers.extend(hkcu_result.managers);
+    let mut environments = hklm_outcome.result.environments;
+    environments.extend(hkcu_outcome.result.environments);
+    let mut managers = hklm_outcome.result.managers;
+    managers.extend(hkcu_outcome.result.managers);
+    let mut conda_install_dirs = hklm_outcome.conda_install_dirs;
+    conda_install_dirs.extend(hkcu_outcome.conda_install_dirs);
 
     RegistryWalkOutcome {
         result: LocatorResult {
             environments,
             managers,
         },
-        had_panic: hklm_panic || hkcu_panic,
+        conda_install_dirs,
+        had_panic: hklm_outcome.had_panic || hkcu_outcome.had_panic,
     }
 }
 
 /// Sibling of `join_or_warn` for hive-level threads. Returns the recovered
-/// `LocatorResult` plus a `had_panic` flag that already accounts for any
-/// company-level panics propagated through `RegistryWalkOutcome`.
+/// outcome (already aggregating any company-level panics) so the top
+/// level can OR the panic flags and concatenate the conda install dirs.
 #[cfg(windows)]
 fn join_hive_outcome(
     join_result: std::thread::Result<RegistryWalkOutcome>,
     label: &str,
-) -> (LocatorResult, bool) {
+) -> RegistryWalkOutcome {
     use log::warn;
     match join_result {
-        Ok(outcome) => (outcome.result, outcome.had_panic),
+        Ok(outcome) => outcome,
         Err(panic_payload) => {
             let message = panic_payload
                 .downcast_ref::<&'static str>()
@@ -134,7 +162,11 @@ fn join_hive_outcome(
                 .or_else(|| panic_payload.downcast_ref::<String>().cloned())
                 .unwrap_or_else(|| "<non-string panic payload>".to_string());
             warn!("Registry walk thread for {} panicked: {}", label, message);
-            (empty_result(), true)
+            RegistryWalkOutcome {
+                result: empty_result(),
+                conda_install_dirs: vec![],
+                had_panic: true,
+            }
         }
     }
 }
@@ -158,6 +190,7 @@ fn get_registry_pythons_for_hive(
             warn!("Failed to open {}\\Software\\Python, {:?}", name, err);
             return RegistryWalkOutcome {
                 result: empty_result(),
+                conda_install_dirs: vec![],
                 had_panic: false,
             };
         }
@@ -183,7 +216,7 @@ fn get_registry_pythons_for_hive(
         })
         .collect();
 
-    let results: Vec<(LocatorResult, bool)> = thread::scope(|s| {
+    let results: Vec<(CompanyWalkOutcome, bool)> = thread::scope(|s| {
         let handles: Vec<_> = companies
             .into_iter()
             .map(|(company, company_key)| {
@@ -214,10 +247,12 @@ fn get_registry_pythons_for_hive(
 
     let mut environments = vec![];
     let mut managers = vec![];
+    let mut conda_install_dirs = vec![];
     let mut had_panic = false;
-    for (r, panicked) in results {
-        environments.extend(r.environments);
-        managers.extend(r.managers);
+    for (outcome, panicked) in results {
+        environments.extend(outcome.result.environments);
+        managers.extend(outcome.result.managers);
+        conda_install_dirs.extend(outcome.conda_install_dirs);
         had_panic |= panicked;
     }
     RegistryWalkOutcome {
@@ -225,6 +260,7 @@ fn get_registry_pythons_for_hive(
             environments,
             managers,
         },
+        conda_install_dirs,
         had_panic,
     }
 }
@@ -236,12 +272,13 @@ fn get_registry_pythons_from_key_for_company(
     company: &str,
     conda_locator: &Arc<dyn CondaLocator>,
     reporter: &Option<&dyn Reporter>,
-) -> LocatorResult {
+) -> CompanyWalkOutcome {
     use log::{trace, warn};
     use pet_conda::utils::is_conda_env;
     use pet_fs::path::norm_case;
 
     let mut environments = vec![];
+    let mut conda_install_dirs = vec![];
     // let company_display_name: Option<String> = company_key.get_value("DisplayName").ok();
     for installed_python in company_key.enum_keys().filter_map(Result::ok) {
         match company_key.open_subkey(installed_python.clone()) {
@@ -281,6 +318,15 @@ fn get_registry_pythons_from_key_for_company(
                             if let Some(reporter) = reporter {
                                 conda_locator.find_and_report(*reporter, &env_path);
                             }
+                            // Capture the dir even when no reporter is
+                            // attached (e.g. cache-warming via
+                            // `find_with_cache(None)`) so a later cache
+                            // hit in `find()` can replay
+                            // `conda_locator.find_and_report` against
+                            // each dir; without this, registry-only conda
+                            // installs would silently disappear from
+                            // every refresh after the first (#454).
+                            conda_install_dirs.push(env_path);
                             continue;
                         }
 
@@ -366,8 +412,11 @@ fn get_registry_pythons_from_key_for_company(
         }
     }
 
-    LocatorResult {
-        environments,
-        managers: vec![],
+    CompanyWalkOutcome {
+        result: LocatorResult {
+            environments,
+            managers: vec![],
+        },
+        conda_install_dirs,
     }
 }

--- a/crates/pet-windows-registry/src/environments.rs
+++ b/crates/pet-windows-registry/src/environments.rs
@@ -141,7 +141,11 @@ fn get_registry_pythons_for_hive(
         let handles: Vec<_> = companies
             .into_iter()
             .map(|(company, company_key)| {
-                s.spawn(move || {
+                // Build the panic-warning label up-front so a panicking
+                // company thread is identifiable in logs (issue #454
+                // Copilot review feedback).
+                let label = format!("{name}\\Software\\Python\\{company}");
+                let handle = s.spawn(move || {
                     // Trace order is intentionally relaxed: companies are
                     // walked in parallel, so this line interleaves with the
                     // others from the same hive.
@@ -153,12 +157,13 @@ fn get_registry_pythons_for_hive(
                         conda_locator,
                         reporter,
                     )
-                })
+                });
+                (label, handle)
             })
             .collect();
         handles
             .into_iter()
-            .map(|h| join_or_warn(h.join(), "per-company walk"))
+            .map(|(label, h)| join_or_warn(h.join(), &label))
             .collect()
     });
 

--- a/crates/pet-windows-registry/src/lib.rs
+++ b/crates/pet-windows-registry/src/lib.rs
@@ -162,21 +162,17 @@ impl Locator for WindowsRegistry {
         }
         #[cfg(windows)]
         {
-            // Read-only cache lookup. We deliberately do NOT trigger a
-            // registry walk from `try_from`: the walk has reporter-only
-            // side effects (notably `conda_locator.find_and_report(...)`)
-            // and `try_from` can't supply a reporter. Populating the
-            // cache here would let a later `find(reporter)` short-circuit
-            // on the cache hit and silently drop those conda
-            // notifications (issue #454).
-            let cached = {
-                let result = self
-                    .search_result
-                    .lock()
-                    .expect("search_result mutex poisoned");
-                result.as_ref().map(Arc::clone)
-            };
-            if let Some(cached) = cached {
+            // Populate (or reuse) the registry-walk cache so we can answer
+            // `try_from` queries for installs that are only discoverable
+            // via HKLM/HKCU. The walk has reporter-only side effects
+            // (notably `conda_locator.find_and_report(...)`) and
+            // `try_from` can't supply a reporter, but that's safe now:
+            // `find_with_cache` records every conda install dir on the
+            // cached `CachedRegistryWalk`, and a later `find(reporter)`
+            // cache hit replays those via `conda_locator.find_and_report`
+            // (#454). Without this `try_from` would never identify
+            // registry-only Pythons before the first `find()` runs.
+            if let Some((cached, _did_walk)) = self.find_with_cache(None) {
                 for found_env in &cached.result.environments {
                     if let Some(ref python_executable_path) = found_env.executable {
                         if python_executable_path == &env.executable {

--- a/crates/pet-windows-registry/src/lib.rs
+++ b/crates/pet-windows-registry/src/lib.rs
@@ -19,7 +19,7 @@ pub struct WindowsRegistry {
     #[allow(dead_code)]
     conda_locator: Arc<dyn CondaLocator>,
     #[allow(dead_code)]
-    search_result: Arc<Mutex<Option<LocatorResult>>>,
+    search_result: Arc<Mutex<Option<Arc<LocatorResult>>>>,
 }
 
 impl WindowsRegistry {
@@ -30,17 +30,17 @@ impl WindowsRegistry {
         }
     }
     #[cfg(windows)]
-    fn find_with_cache(&self, reporter: Option<&dyn Reporter>) -> Option<LocatorResult> {
+    fn find_with_cache(&self, reporter: Option<&dyn Reporter>) -> Option<Arc<LocatorResult>> {
         let mut result = self
             .search_result
             .lock()
             .expect("search_result mutex poisoned");
-        if let Some(result) = result.clone() {
-            return Some(result);
+        if let Some(result) = result.as_ref() {
+            return Some(Arc::clone(result));
         }
 
-        let registry_result = get_registry_pythons(&self.conda_locator, &reporter);
-        result.replace(registry_result.clone());
+        let registry_result = Arc::new(get_registry_pythons(&self.conda_locator, &reporter));
+        result.replace(Arc::clone(&registry_result));
 
         Some(registry_result)
     }
@@ -111,10 +111,10 @@ impl Locator for WindowsRegistry {
         #[cfg(windows)]
         if let Some(result) = self.find_with_cache(None) {
             // Find the same env here
-            for found_env in result.environments {
+            for found_env in &result.environments {
                 if let Some(ref python_executable_path) = found_env.executable {
                     if python_executable_path == &env.executable {
-                        return Some(found_env);
+                        return Some(found_env.clone());
                     }
                 }
             }
@@ -135,12 +135,15 @@ impl Locator for WindowsRegistry {
         // replay the cached environments/managers to the reporter
         // ourselves — otherwise WindowsRegistry discoveries would silently
         // disappear on every refresh after the first.
+        //
+        // The cache stores an `Arc<LocatorResult>`, so the lookup is a
+        // cheap pointer clone — no deep copy of the underlying vectors.
         let cached = {
             let result = self
                 .search_result
                 .lock()
                 .expect("search_result mutex poisoned");
-            result.clone()
+            result.as_ref().map(Arc::clone)
         };
         if let Some(cached) = cached {
             for manager in &cached.managers {
@@ -221,24 +224,28 @@ mod tests {
         let shared = create_locator();
         let refreshed = create_locator();
 
-        shared.search_result.lock().unwrap().replace(LocatorResult {
-            managers: vec![],
-            environments: vec![PythonEnvironment {
-                name: Some("stale".to_string()),
-                ..Default::default()
-            }],
-        });
+        shared
+            .search_result
+            .lock()
+            .unwrap()
+            .replace(Arc::new(LocatorResult {
+                managers: vec![],
+                environments: vec![PythonEnvironment {
+                    name: Some("stale".to_string()),
+                    ..Default::default()
+                }],
+            }));
         refreshed
             .search_result
             .lock()
             .unwrap()
-            .replace(LocatorResult {
+            .replace(Arc::new(LocatorResult {
                 managers: vec![],
                 environments: vec![PythonEnvironment {
                     name: Some("fresh".to_string()),
                     ..Default::default()
                 }],
-            });
+            }));
 
         shared.sync_refresh_state_from(&refreshed, &RefreshStateSyncScope::Full);
 
@@ -251,24 +258,28 @@ mod tests {
         let shared = create_locator();
         let refreshed = create_locator();
 
-        shared.search_result.lock().unwrap().replace(LocatorResult {
-            managers: vec![],
-            environments: vec![PythonEnvironment {
-                name: Some("stale".to_string()),
-                ..Default::default()
-            }],
-        });
+        shared
+            .search_result
+            .lock()
+            .unwrap()
+            .replace(Arc::new(LocatorResult {
+                managers: vec![],
+                environments: vec![PythonEnvironment {
+                    name: Some("stale".to_string()),
+                    ..Default::default()
+                }],
+            }));
         refreshed
             .search_result
             .lock()
             .unwrap()
-            .replace(LocatorResult {
+            .replace(Arc::new(LocatorResult {
                 managers: vec![],
                 environments: vec![PythonEnvironment {
                     name: Some("fresh".to_string()),
                     ..Default::default()
                 }],
-            });
+            }));
 
         shared.sync_refresh_state_from(&refreshed, &RefreshStateSyncScope::Workspace);
 
@@ -281,24 +292,28 @@ mod tests {
         let shared = create_locator();
         let refreshed = create_locator();
 
-        shared.search_result.lock().unwrap().replace(LocatorResult {
-            managers: vec![],
-            environments: vec![PythonEnvironment {
-                name: Some("stale".to_string()),
-                ..Default::default()
-            }],
-        });
+        shared
+            .search_result
+            .lock()
+            .unwrap()
+            .replace(Arc::new(LocatorResult {
+                managers: vec![],
+                environments: vec![PythonEnvironment {
+                    name: Some("stale".to_string()),
+                    ..Default::default()
+                }],
+            }));
         refreshed
             .search_result
             .lock()
             .unwrap()
-            .replace(LocatorResult {
+            .replace(Arc::new(LocatorResult {
                 managers: vec![],
                 environments: vec![PythonEnvironment {
                     name: Some("fresh".to_string()),
                     ..Default::default()
                 }],
-            });
+            }));
 
         shared.sync_refresh_state_from(
             &refreshed,
@@ -307,13 +322,17 @@ mod tests {
         let result = shared.search_result.lock().unwrap().clone().unwrap();
         assert_eq!(result.environments[0].name.as_deref(), Some("fresh"));
 
-        shared.search_result.lock().unwrap().replace(LocatorResult {
-            managers: vec![],
-            environments: vec![PythonEnvironment {
-                name: Some("stale".to_string()),
-                ..Default::default()
-            }],
-        });
+        shared
+            .search_result
+            .lock()
+            .unwrap()
+            .replace(Arc::new(LocatorResult {
+                managers: vec![],
+                environments: vec![PythonEnvironment {
+                    name: Some("stale".to_string()),
+                    ..Default::default()
+                }],
+            }));
 
         shared.sync_refresh_state_from(
             &refreshed,
@@ -402,7 +421,7 @@ mod tests {
             .search_result
             .lock()
             .unwrap()
-            .replace(cached.clone());
+            .replace(Arc::new(cached.clone()));
 
         let reporter = RecordingReporter::default();
         locator.find(&reporter);

--- a/crates/pet-windows-registry/src/lib.rs
+++ b/crates/pet-windows-registry/src/lib.rs
@@ -11,7 +11,6 @@ use pet_core::{
     Locator, LocatorKind, LocatorResult, RefreshStatePersistence, RefreshStateSyncScope,
 };
 use pet_virtualenv::is_virtualenv;
-#[cfg(windows)]
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -24,9 +23,10 @@ mod environments;
 /// reporter (not into `LocatorResult`); without remembering the dirs,
 /// every cache hit in `find()` would silently drop registry-only conda
 /// notifications (issue #454).
-#[cfg(windows)]
 struct CachedRegistryWalk {
+    #[cfg_attr(not(windows), allow(dead_code))]
     result: LocatorResult,
+    #[cfg_attr(not(windows), allow(dead_code))]
     conda_install_dirs: Vec<PathBuf>,
 }
 
@@ -34,11 +34,7 @@ pub struct WindowsRegistry {
     #[allow(dead_code)]
     conda_locator: Arc<dyn CondaLocator>,
     #[allow(dead_code)]
-    #[cfg(windows)]
     search_result: Arc<Mutex<Option<Arc<CachedRegistryWalk>>>>,
-    #[allow(dead_code)]
-    #[cfg(not(windows))]
-    search_result: Arc<Mutex<Option<Arc<LocatorResult>>>>,
 }
 
 impl WindowsRegistry {
@@ -262,7 +258,6 @@ mod tests {
         WindowsRegistry::from(Arc::new(Conda::from(&environment)))
     }
 
-    #[cfg(windows)]
     fn wrap_cached(result: LocatorResult) -> Arc<CachedRegistryWalk> {
         Arc::new(CachedRegistryWalk {
             result,

--- a/crates/pet-windows-registry/src/lib.rs
+++ b/crates/pet-windows-registry/src/lib.rs
@@ -44,14 +44,6 @@ impl WindowsRegistry {
 
         Some(registry_result)
     }
-    #[cfg(windows)]
-    fn clear(&self) {
-        let mut search_result = self
-            .search_result
-            .lock()
-            .expect("search_result mutex poisoned");
-        search_result.take();
-    }
 
     fn sync_search_result_from(&self, source: &WindowsRegistry) {
         let search_result = source
@@ -132,7 +124,12 @@ impl Locator for WindowsRegistry {
 
     #[cfg(windows)]
     fn find(&self, reporter: &dyn Reporter) {
-        self.clear();
+        // We no longer reset `search_result` here: `find_with_cache` already
+        // returns the cached result on a hit, and `find()` is invoked on
+        // transient locators per refresh, so the cache is empty by
+        // construction the first time. Re-clearing forced every refresh to
+        // re-walk both registry hives, each of which is intercepted by
+        // Windows Defender (issue #454).
         let _ = self.find_with_cache(Some(reporter));
     }
     #[cfg(unix)]
@@ -325,5 +322,91 @@ mod tests {
         let locator = create_locator();
 
         assert!(locator.try_from(&env).is_none());
+    }
+
+    /// `find()` must NOT clear the cache before populating it. The previous
+    /// implementation called `self.clear()` first, which forced every
+    /// `refresh` RPC to re-walk both registry hives — a Defender-intercepted
+    /// hot path tracked in #454. This test pins down the new contract:
+    /// pre-populate the cache, run `find()`, and assert the original entries
+    /// survived (i.e. `find_with_cache` short-circuited on the cache hit).
+    #[cfg(windows)]
+    #[test]
+    fn test_find_reuses_cached_results_within_locator_lifetime() {
+        use pet_core::manager::EnvManager;
+        use pet_core::python_environment::PythonEnvironment;
+        use pet_core::reporter::Reporter;
+        use pet_core::telemetry::TelemetryEvent;
+
+        struct CountingReporter;
+        impl Reporter for CountingReporter {
+            fn report_manager(&self, _manager: &EnvManager) {}
+            fn report_environment(&self, _env: &PythonEnvironment) {}
+            fn report_telemetry(&self, _event: &TelemetryEvent) {}
+        }
+
+        let locator = create_locator();
+        let cached = LocatorResult {
+            managers: vec![],
+            environments: vec![PythonEnvironment {
+                name: Some("cached".to_string()),
+                ..Default::default()
+            }],
+        };
+        locator
+            .search_result
+            .lock()
+            .unwrap()
+            .replace(cached.clone());
+
+        locator.find(&CountingReporter);
+
+        let after = locator
+            .search_result
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("cache must remain populated after find()");
+        assert_eq!(
+            after.environments.len(),
+            1,
+            "find() must not clear the cache before populating",
+        );
+        assert_eq!(after.environments[0].name.as_deref(), Some("cached"));
+    }
+
+    /// Smoke test: on a fresh locator (empty cache), `find()` runs the new
+    /// parallel walk through HKLM and HKCU and never panics or deadlocks.
+    /// The discovered environment list may legitimately be empty on a CI
+    /// runner without any Python registry installs — we only assert the
+    /// cache was populated (i.e. the walk completed and `Some(_)` was
+    /// stored), not its contents.
+    #[cfg(windows)]
+    #[test]
+    fn test_find_on_fresh_locator_completes_parallel_walk() {
+        use pet_core::manager::EnvManager;
+        use pet_core::python_environment::PythonEnvironment;
+        use pet_core::reporter::Reporter;
+        use pet_core::telemetry::TelemetryEvent;
+
+        struct NoopReporter;
+        impl Reporter for NoopReporter {
+            fn report_manager(&self, _manager: &EnvManager) {}
+            fn report_environment(&self, _env: &PythonEnvironment) {}
+            fn report_telemetry(&self, _event: &TelemetryEvent) {}
+        }
+
+        let locator = create_locator();
+        assert!(
+            locator.search_result.lock().unwrap().is_none(),
+            "freshly built locator must start with an empty cache",
+        );
+
+        locator.find(&NoopReporter);
+
+        assert!(
+            locator.search_result.lock().unwrap().is_some(),
+            "find() must populate the cache after walking both hives",
+        );
     }
 }

--- a/crates/pet-windows-registry/src/lib.rs
+++ b/crates/pet-windows-registry/src/lib.rs
@@ -31,21 +31,39 @@ impl WindowsRegistry {
     }
     #[cfg(windows)]
     fn find_with_cache(&self, reporter: Option<&dyn Reporter>) -> Option<Arc<LocatorResult>> {
-        let mut result = self
-            .search_result
-            .lock()
-            .expect("search_result mutex poisoned");
-        if let Some(result) = result.as_ref() {
-            return Some(Arc::clone(result));
+        // Quick cache check, then drop the lock before doing any expensive
+        // work. Holding `search_result`'s mutex across `get_registry_pythons`
+        // would serialize all callers behind one Defender-intercepted
+        // registry walk and create lock-order risk against any locks the
+        // reporter / conda locator take downstream (issue #454).
+        {
+            let cached = self
+                .search_result
+                .lock()
+                .expect("search_result mutex poisoned");
+            if let Some(cached) = cached.as_ref() {
+                return Some(Arc::clone(cached));
+            }
         }
 
         let outcome = get_registry_pythons(&self.conda_locator, &reporter);
         let registry_result = Arc::new(outcome.result);
+
         // If any worker thread panicked, the result is potentially partial.
         // Skip persisting it so the next refresh can retry the walk instead
         // of replaying a stale empty/partial cache forever (issue #454).
         if !outcome.had_panic {
-            result.replace(Arc::clone(&registry_result));
+            let mut cached = self
+                .search_result
+                .lock()
+                .expect("search_result mutex poisoned");
+            // Re-check under the lock: another caller may have populated
+            // the cache while we were walking. Prefer their value so all
+            // callers observe the same identity.
+            if let Some(existing) = cached.as_ref() {
+                return Some(Arc::clone(existing));
+            }
+            cached.replace(Arc::clone(&registry_result));
         }
 
         Some(registry_result)
@@ -115,12 +133,27 @@ impl Locator for WindowsRegistry {
             }
         }
         #[cfg(windows)]
-        if let Some(result) = self.find_with_cache(None) {
-            // Find the same env here
-            for found_env in &result.environments {
-                if let Some(ref python_executable_path) = found_env.executable {
-                    if python_executable_path == &env.executable {
-                        return Some(found_env.clone());
+        {
+            // Read-only cache lookup. We deliberately do NOT trigger a
+            // registry walk from `try_from`: the walk has reporter-only
+            // side effects (notably `conda_locator.find_and_report(...)`)
+            // and `try_from` can't supply a reporter. Populating the
+            // cache here would let a later `find(reporter)` short-circuit
+            // on the cache hit and silently drop those conda
+            // notifications (issue #454).
+            let cached = {
+                let result = self
+                    .search_result
+                    .lock()
+                    .expect("search_result mutex poisoned");
+                result.as_ref().map(Arc::clone)
+            };
+            if let Some(result) = cached {
+                for found_env in &result.environments {
+                    if let Some(ref python_executable_path) = found_env.executable {
+                        if python_executable_path == &env.executable {
+                            return Some(found_env.clone());
+                        }
                     }
                 }
             }

--- a/crates/pet-windows-registry/src/lib.rs
+++ b/crates/pet-windows-registry/src/lib.rs
@@ -169,7 +169,14 @@ impl Locator for WindowsRegistry {
             // cache here would let a later `find(reporter)` short-circuit
             // on the cache hit and silently drop those conda
             // notifications (issue #454).
-            if let Some((cached, _did_walk)) = self.find_with_cache(None) {
+            let cached = {
+                let result = self
+                    .search_result
+                    .lock()
+                    .expect("search_result mutex poisoned");
+                result.as_ref().map(Arc::clone)
+            };
+            if let Some(cached) = cached {
                 for found_env in &cached.result.environments {
                     if let Some(ref python_executable_path) = found_env.executable {
                         if python_executable_path == &env.executable {

--- a/crates/pet-windows-registry/src/lib.rs
+++ b/crates/pet-windows-registry/src/lib.rs
@@ -124,12 +124,35 @@ impl Locator for WindowsRegistry {
 
     #[cfg(windows)]
     fn find(&self, reporter: &dyn Reporter) {
-        // We no longer reset `search_result` here: `find_with_cache` already
-        // returns the cached result on a hit, and `find()` is invoked on
-        // transient locators per refresh, so the cache is empty by
-        // construction the first time. Re-clearing forced every refresh to
-        // re-walk both registry hives, each of which is intercepted by
-        // Windows Defender (issue #454).
+        // We no longer reset `search_result` here: the cache may have been
+        // populated via `sync_refresh_state_from` between refreshes, and
+        // `find()` is invoked on transient locators per refresh, so on the
+        // first refresh the cache is empty by construction. Re-clearing
+        // forced every refresh to re-walk both registry hives, each of
+        // which is intercepted by Windows Defender (issue #454).
+        //
+        // On a cache hit `get_registry_pythons` is NOT called, so we must
+        // replay the cached environments/managers to the reporter
+        // ourselves — otherwise WindowsRegistry discoveries would silently
+        // disappear on every refresh after the first.
+        let cached = {
+            let result = self
+                .search_result
+                .lock()
+                .expect("search_result mutex poisoned");
+            result.clone()
+        };
+        if let Some(cached) = cached {
+            for manager in &cached.managers {
+                reporter.report_manager(manager);
+            }
+            for env in &cached.environments {
+                reporter.report_environment(env);
+            }
+            return;
+        }
+        // Cache miss: walk the registry. `get_registry_pythons` reports
+        // inline as it discovers entries, so no separate replay is needed.
         let _ = self.find_with_cache(Some(reporter));
     }
     #[cfg(unix)]
@@ -328,8 +351,10 @@ mod tests {
     /// implementation called `self.clear()` first, which forced every
     /// `refresh` RPC to re-walk both registry hives — a Defender-intercepted
     /// hot path tracked in #454. This test pins down the new contract:
-    /// pre-populate the cache, run `find()`, and assert the original entries
-    /// survived (i.e. `find_with_cache` short-circuited on the cache hit).
+    /// pre-populate the cache, run `find()`, and assert (a) the original
+    /// entries survived (i.e. the cache was not cleared) and (b) the
+    /// reporter was notified with the cached environments and managers,
+    /// so cached results are still observable to refresh consumers.
     #[cfg(windows)]
     #[test]
     fn test_find_reuses_cached_results_within_locator_lifetime() {
@@ -337,17 +362,37 @@ mod tests {
         use pet_core::python_environment::PythonEnvironment;
         use pet_core::reporter::Reporter;
         use pet_core::telemetry::TelemetryEvent;
+        use std::sync::Mutex;
 
-        struct CountingReporter;
-        impl Reporter for CountingReporter {
-            fn report_manager(&self, _manager: &EnvManager) {}
-            fn report_environment(&self, _env: &PythonEnvironment) {}
+        #[derive(Default)]
+        struct RecordingReporter {
+            environments: Mutex<Vec<String>>,
+            managers: Mutex<Vec<PathBuf>>,
+        }
+        impl Reporter for RecordingReporter {
+            fn report_manager(&self, manager: &EnvManager) {
+                self.managers
+                    .lock()
+                    .unwrap()
+                    .push(manager.executable.clone());
+            }
+            fn report_environment(&self, env: &PythonEnvironment) {
+                self.environments
+                    .lock()
+                    .unwrap()
+                    .push(env.name.clone().unwrap_or_default());
+            }
             fn report_telemetry(&self, _event: &TelemetryEvent) {}
         }
 
         let locator = create_locator();
+        let cached_manager = EnvManager::new(
+            PathBuf::from("C:\\fake\\python.exe"),
+            pet_core::manager::EnvManagerType::Conda,
+            None,
+        );
         let cached = LocatorResult {
-            managers: vec![],
+            managers: vec![cached_manager.clone()],
             environments: vec![PythonEnvironment {
                 name: Some("cached".to_string()),
                 ..Default::default()
@@ -359,8 +404,10 @@ mod tests {
             .unwrap()
             .replace(cached.clone());
 
-        locator.find(&CountingReporter);
+        let reporter = RecordingReporter::default();
+        locator.find(&reporter);
 
+        // (a) The cache must still be populated and unchanged.
         let after = locator
             .search_result
             .lock()
@@ -373,6 +420,19 @@ mod tests {
             "find() must not clear the cache before populating",
         );
         assert_eq!(after.environments[0].name.as_deref(), Some("cached"));
+        // (b) The cached entries must have been replayed to the reporter
+        // — otherwise WindowsRegistry discoveries would silently
+        // disappear on every refresh after the first.
+        assert_eq!(
+            reporter.environments.lock().unwrap().as_slice(),
+            &["cached".to_string()],
+            "find() must replay cached environments to the reporter on a cache hit",
+        );
+        assert_eq!(
+            reporter.managers.lock().unwrap().as_slice(),
+            &[PathBuf::from("C:\\fake\\python.exe")],
+            "find() must replay cached managers to the reporter on a cache hit",
+        );
     }
 
     /// Smoke test: on a fresh locator (empty cache), `find()` runs the new

--- a/crates/pet-windows-registry/src/lib.rs
+++ b/crates/pet-windows-registry/src/lib.rs
@@ -11,14 +11,33 @@ use pet_core::{
     Locator, LocatorKind, LocatorResult, RefreshStatePersistence, RefreshStateSyncScope,
 };
 use pet_virtualenv::is_virtualenv;
+#[cfg(windows)]
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 mod environments;
+
+/// Cached output of a full registry walk. Holds the registry-derived
+/// `LocatorResult` plus the conda install dirs discovered via the
+/// registry. The conda dirs are kept separately because
+/// `conda_locator.find_and_report` writes its findings directly to the
+/// reporter (not into `LocatorResult`); without remembering the dirs,
+/// every cache hit in `find()` would silently drop registry-only conda
+/// notifications (issue #454).
+#[cfg(windows)]
+struct CachedRegistryWalk {
+    result: LocatorResult,
+    conda_install_dirs: Vec<PathBuf>,
+}
 
 pub struct WindowsRegistry {
     #[allow(dead_code)]
     conda_locator: Arc<dyn CondaLocator>,
     #[allow(dead_code)]
+    #[cfg(windows)]
+    search_result: Arc<Mutex<Option<Arc<CachedRegistryWalk>>>>,
+    #[allow(dead_code)]
+    #[cfg(not(windows))]
     search_result: Arc<Mutex<Option<Arc<LocatorResult>>>>,
 }
 
@@ -30,24 +49,35 @@ impl WindowsRegistry {
         }
     }
     #[cfg(windows)]
-    fn find_with_cache(&self, reporter: Option<&dyn Reporter>) -> Option<Arc<LocatorResult>> {
+    fn find_with_cache(
+        &self,
+        reporter: Option<&dyn Reporter>,
+    ) -> Option<(Arc<CachedRegistryWalk>, bool)> {
         // Quick cache check, then drop the lock before doing any expensive
         // work. Holding `search_result`'s mutex across `get_registry_pythons`
         // would serialize all callers behind one Defender-intercepted
         // registry walk and create lock-order risk against any locks the
         // reporter / conda locator take downstream (issue #454).
+        //
+        // Returns `(walk, did_walk)` so the caller can replay
+        // notifications when we did NOT walk (cache hit) and avoid
+        // double-reporting when we did (the walk already reported
+        // inline).
         {
             let cached = self
                 .search_result
                 .lock()
                 .expect("search_result mutex poisoned");
             if let Some(cached) = cached.as_ref() {
-                return Some(Arc::clone(cached));
+                return Some((Arc::clone(cached), false));
             }
         }
 
         let outcome = get_registry_pythons(&self.conda_locator, &reporter);
-        let registry_result = Arc::new(outcome.result);
+        let cached_walk = Arc::new(CachedRegistryWalk {
+            result: outcome.result,
+            conda_install_dirs: outcome.conda_install_dirs,
+        });
 
         // If any worker thread panicked, the result is potentially partial.
         // Skip persisting it so the next refresh can retry the walk instead
@@ -59,14 +89,16 @@ impl WindowsRegistry {
                 .expect("search_result mutex poisoned");
             // Re-check under the lock: another caller may have populated
             // the cache while we were walking. Prefer their value so all
-            // callers observe the same identity.
+            // callers observe the same identity. We still report
+            // `did_walk = true` because OUR reporter (if any) already
+            // received inline notifications during the walk.
             if let Some(existing) = cached.as_ref() {
-                return Some(Arc::clone(existing));
+                return Some((Arc::clone(existing), true));
             }
-            cached.replace(Arc::clone(&registry_result));
+            cached.replace(Arc::clone(&cached_walk));
         }
 
-        Some(registry_result)
+        Some((cached_walk, true))
     }
 
     fn sync_search_result_from(&self, source: &WindowsRegistry) {
@@ -141,15 +173,8 @@ impl Locator for WindowsRegistry {
             // cache here would let a later `find(reporter)` short-circuit
             // on the cache hit and silently drop those conda
             // notifications (issue #454).
-            let cached = {
-                let result = self
-                    .search_result
-                    .lock()
-                    .expect("search_result mutex poisoned");
-                result.as_ref().map(Arc::clone)
-            };
-            if let Some(result) = cached {
-                for found_env in &result.environments {
+            if let Some((cached, _did_walk)) = self.find_with_cache(None) {
+                for found_env in &cached.result.environments {
                     if let Some(ref python_executable_path) = found_env.executable {
                         if python_executable_path == &env.executable {
                             return Some(found_env.clone());
@@ -170,32 +195,29 @@ impl Locator for WindowsRegistry {
         // forced every refresh to re-walk both registry hives, each of
         // which is intercepted by Windows Defender (issue #454).
         //
-        // On a cache hit `get_registry_pythons` is NOT called, so we must
-        // replay the cached environments/managers to the reporter
-        // ourselves — otherwise WindowsRegistry discoveries would silently
-        // disappear on every refresh after the first.
-        //
-        // The cache stores an `Arc<LocatorResult>`, so the lookup is a
-        // cheap pointer clone — no deep copy of the underlying vectors.
-        let cached = {
-            let result = self
-                .search_result
-                .lock()
-                .expect("search_result mutex poisoned");
-            result.as_ref().map(Arc::clone)
-        };
-        if let Some(cached) = cached {
-            for manager in &cached.managers {
-                reporter.report_manager(manager);
+        // `find_with_cache` returns `(cached, did_walk)`. When it walked,
+        // `get_registry_pythons` already reported entries inline to our
+        // reporter, so we must NOT replay (that would double-report).
+        // When it did NOT walk — either the first cache check hit, or
+        // another thread populated the cache while we were entering — we
+        // own the replay: registry environments and managers, plus a
+        // re-invocation of `conda_locator.find_and_report` for each
+        // cached conda install dir (those notifications go straight to
+        // the reporter and aren't part of `LocatorResult`, so they would
+        // otherwise silently disappear after the first refresh, #454).
+        if let Some((cached, did_walk)) = self.find_with_cache(Some(reporter)) {
+            if !did_walk {
+                for manager in &cached.result.managers {
+                    reporter.report_manager(manager);
+                }
+                for env in &cached.result.environments {
+                    reporter.report_environment(env);
+                }
+                for conda_dir in &cached.conda_install_dirs {
+                    self.conda_locator.find_and_report(reporter, conda_dir);
+                }
             }
-            for env in &cached.environments {
-                reporter.report_environment(env);
-            }
-            return;
         }
-        // Cache miss: walk the registry. `get_registry_pythons` reports
-        // inline as it discovers entries, so no separate replay is needed.
-        let _ = self.find_with_cache(Some(reporter));
     }
     #[cfg(unix)]
     fn find(&self, _reporter: &dyn Reporter) {
@@ -240,6 +262,14 @@ mod tests {
         WindowsRegistry::from(Arc::new(Conda::from(&environment)))
     }
 
+    #[cfg(windows)]
+    fn wrap_cached(result: LocatorResult) -> Arc<CachedRegistryWalk> {
+        Arc::new(CachedRegistryWalk {
+            result,
+            conda_install_dirs: vec![],
+        })
+    }
+
     #[test]
     fn test_windows_registry_reports_kind_categories_and_refresh_state() {
         let locator = create_locator();
@@ -267,7 +297,7 @@ mod tests {
             .search_result
             .lock()
             .unwrap()
-            .replace(Arc::new(LocatorResult {
+            .replace(wrap_cached(LocatorResult {
                 managers: vec![],
                 environments: vec![PythonEnvironment {
                     name: Some("stale".to_string()),
@@ -278,7 +308,7 @@ mod tests {
             .search_result
             .lock()
             .unwrap()
-            .replace(Arc::new(LocatorResult {
+            .replace(wrap_cached(LocatorResult {
                 managers: vec![],
                 environments: vec![PythonEnvironment {
                     name: Some("fresh".to_string()),
@@ -289,7 +319,7 @@ mod tests {
         shared.sync_refresh_state_from(&refreshed, &RefreshStateSyncScope::Full);
 
         let result = shared.search_result.lock().unwrap().clone().unwrap();
-        assert_eq!(result.environments[0].name.as_deref(), Some("fresh"));
+        assert_eq!(result.result.environments[0].name.as_deref(), Some("fresh"));
     }
 
     #[test]
@@ -301,7 +331,7 @@ mod tests {
             .search_result
             .lock()
             .unwrap()
-            .replace(Arc::new(LocatorResult {
+            .replace(wrap_cached(LocatorResult {
                 managers: vec![],
                 environments: vec![PythonEnvironment {
                     name: Some("stale".to_string()),
@@ -312,7 +342,7 @@ mod tests {
             .search_result
             .lock()
             .unwrap()
-            .replace(Arc::new(LocatorResult {
+            .replace(wrap_cached(LocatorResult {
                 managers: vec![],
                 environments: vec![PythonEnvironment {
                     name: Some("fresh".to_string()),
@@ -323,7 +353,7 @@ mod tests {
         shared.sync_refresh_state_from(&refreshed, &RefreshStateSyncScope::Workspace);
 
         let result = shared.search_result.lock().unwrap().clone().unwrap();
-        assert_eq!(result.environments[0].name.as_deref(), Some("stale"));
+        assert_eq!(result.result.environments[0].name.as_deref(), Some("stale"));
     }
 
     #[test]
@@ -335,7 +365,7 @@ mod tests {
             .search_result
             .lock()
             .unwrap()
-            .replace(Arc::new(LocatorResult {
+            .replace(wrap_cached(LocatorResult {
                 managers: vec![],
                 environments: vec![PythonEnvironment {
                     name: Some("stale".to_string()),
@@ -346,7 +376,7 @@ mod tests {
             .search_result
             .lock()
             .unwrap()
-            .replace(Arc::new(LocatorResult {
+            .replace(wrap_cached(LocatorResult {
                 managers: vec![],
                 environments: vec![PythonEnvironment {
                     name: Some("fresh".to_string()),
@@ -359,13 +389,13 @@ mod tests {
             &RefreshStateSyncScope::GlobalFiltered(PythonEnvironmentKind::WindowsRegistry),
         );
         let result = shared.search_result.lock().unwrap().clone().unwrap();
-        assert_eq!(result.environments[0].name.as_deref(), Some("fresh"));
+        assert_eq!(result.result.environments[0].name.as_deref(), Some("fresh"));
 
         shared
             .search_result
             .lock()
             .unwrap()
-            .replace(Arc::new(LocatorResult {
+            .replace(wrap_cached(LocatorResult {
                 managers: vec![],
                 environments: vec![PythonEnvironment {
                     name: Some("stale".to_string()),
@@ -378,7 +408,7 @@ mod tests {
             &RefreshStateSyncScope::GlobalFiltered(PythonEnvironmentKind::Venv),
         );
         let result = shared.search_result.lock().unwrap().clone().unwrap();
-        assert_eq!(result.environments[0].name.as_deref(), Some("stale"));
+        assert_eq!(result.result.environments[0].name.as_deref(), Some("stale"));
     }
 
     #[test]
@@ -460,7 +490,7 @@ mod tests {
             .search_result
             .lock()
             .unwrap()
-            .replace(Arc::new(cached.clone()));
+            .replace(wrap_cached(cached.clone()));
 
         let reporter = RecordingReporter::default();
         locator.find(&reporter);
@@ -473,11 +503,11 @@ mod tests {
             .clone()
             .expect("cache must remain populated after find()");
         assert_eq!(
-            after.environments.len(),
+            after.result.environments.len(),
             1,
             "find() must not clear the cache before populating",
         );
-        assert_eq!(after.environments[0].name.as_deref(), Some("cached"));
+        assert_eq!(after.result.environments[0].name.as_deref(), Some("cached"));
         // (b) The cached entries must have been replayed to the reporter
         // — otherwise WindowsRegistry discoveries would silently
         // disappear on every refresh after the first.

--- a/crates/pet-windows-registry/src/lib.rs
+++ b/crates/pet-windows-registry/src/lib.rs
@@ -39,8 +39,14 @@ impl WindowsRegistry {
             return Some(Arc::clone(result));
         }
 
-        let registry_result = Arc::new(get_registry_pythons(&self.conda_locator, &reporter));
-        result.replace(Arc::clone(&registry_result));
+        let outcome = get_registry_pythons(&self.conda_locator, &reporter);
+        let registry_result = Arc::new(outcome.result);
+        // If any worker thread panicked, the result is potentially partial.
+        // Skip persisting it so the next refresh can retry the walk instead
+        // of replaying a stale empty/partial cache forever (issue #454).
+        if !outcome.had_panic {
+            result.replace(Arc::clone(&registry_result));
+        }
 
         Some(registry_result)
     }


### PR DESCRIPTION
Fixes #454.

The `WindowsRegistry` locator walked HKLM and HKCU **serially** on every `refresh`, with no per-company parallelism either, despite `pet-pyenv` / `pet-homebrew` / `pet-conda` already establishing the `thread::scope` pattern. On Windows hosts with Defender intercepting every registry read, this was a measurable contributor to the steady-state p90 refresh latency (#454).

## Changes

- **Parallelize HKLM and HKCU** using `thread::scope` (pyenv pattern). Each hive runs in its own scoped thread; results are stitched back in a deterministic HKLM-then-HKCU order.
- **Parallelize per-company within each hive.** Companies are enumerated and their subkeys opened serially (cheap handle ops), then each is moved into its own scoped thread. `winreg::RegKey: Send + !Sync`, so each thread owns its handle by value — no `&RegKey` crosses a thread boundary.
- **Drop the `self.clear()` at the top of `find()`.** `find_with_cache` already short-circuits on a cache hit, and `find()` runs on transient locators per refresh (the cache is empty by construction the first time), so the unconditional clear was forcing every `refresh` RPC to pay full registry-walk cost. Makes `find()` idempotent.
- **Don't silently swallow panics in spawned threads.** New `join_or_warn(...)` helper logs the panic payload via `warn!` before substituting `empty_result()` so a thread crash in one hive/company doesn't make the entire walk silently disappear.

## Tests

- `test_find_reuses_cached_results_within_locator_lifetime` — pre-populates the cache, runs `find()`, asserts entries survived (pins down the `clear()` removal).
- `test_find_on_fresh_locator_completes_parallel_walk` — runs `find()` on an empty cache and asserts the cache becomes `Some(_)`. Smoke-test for the new parallel scaffolding; doesn't depend on registry contents so passes on CI hosts without Python installs.

## Out of scope

The "split `WindowsRegistry` timing into HKLM vs HKCU in `RefreshPerformance`" telemetry follow-up mentioned in #454 is a separate change; happy to file as its own issue if useful.