### PR TITLE
chore: add rust-precommit skill and cross-platform script

### DIFF
--- a/.github/agents/pr-shepherd.agent.md
+++ b/.github/agents/pr-shepherd.agent.md
@@ -1,0 +1,161 @@
+---
+name: "pr-shepherd"
+description: "Autonomous PR review lifecycle agent. Pushes code, requests Copilot review, polls for comments, fixes issues, runs pre-commit checks, resolves threads, and re-requests review — looping until approved or timeout. Eliminates manual 'more comments' / 'check for comments' prompts."
+tools:
+  - "execute/runInTerminal"
+  - "execute/getTerminalOutput"
+  - "execute/awaitTerminal"
+  - "execute/killTerminal"
+  - "execute/testFailure"
+  - "read/readFile"
+  - "read/problems"
+  - "read/terminalLastCommand"
+  - "read/terminalSelection"
+  - "edit/editFiles"
+  - "edit/createFile"
+  - "search"
+  - "agent"
+  - "github/add_comment_to_pending_review"
+  - "github/add_issue_comment"
+  - "github/create_pull_request"
+  - "github/get_label"
+  - "github/issue_read"
+  - "github/list_branches"
+  - "github/list_commits"
+  - "github/list_pull_requests"
+  - "github/merge_pull_request"
+  - "github/pull_request_read"
+  - "github/pull_request_review_write"
+  - "github/request_copilot_review"
+  - "github/search_issues"
+  - "github/search_pull_requests"
+  - "github/update_pull_request"
+  - "github/update_pull_request_branch"
+  - "todo"
+user-invocable: false
+---
+
+# PR Shepherd
+
+Autonomous agent that manages the PR review lifecycle end-to-end. Replaces manual "more comments" / "check for comments" / "address comments" polling.
+
+## Prime Directive
+
+**Drive a PR from "pushed" to "approved" with zero user intervention.** Only yield when the PR is approved, merged, or you've exhausted your retry budget.
+
+---
+
+## Workflow
+
+### Phase 1: Setup
+
+1. Identify the current PR:
+   - If a PR URL is provided, use it
+   - Otherwise, detect from the current branch (`git branch --show-current`) and find the matching open PR
+   - If no PR exists, create one using `github/create_pull_request`
+
+2. Ensure latest code is pushed:
+   ```
+   git push origin <current-branch>
+   ```
+
+### Phase 2: Request Review
+
+1. Request Copilot review using `github/request_copilot_review`
+2. Wait 2 minutes for the initial review
+
+### Phase 3: Poll & Process (Loop)
+
+**Repeat up to 5 cycles:**
+
+1. **Check for review comments:**
+
+   ```
+   github/pull_request_read (method: get_review_comments)
+   ```
+
+2. **If no actionable comments:**
+   - Check if PR is approved → Phase 5 (done)
+   - If review is still pending, wait 30 seconds and re-check
+   - After 3 consecutive empty checks, consider review complete
+
+3. **If comments exist:**
+   a. Read each unresolved, non-outdated comment
+   b. Understand the requested change
+   c. Make the code fix in the relevant file
+   d. Run pre-commit checks:
+   ```bash
+   cargo fmt --all
+   cargo clippy --all -- -D warnings
+   ```
+   If clippy fails, fix the errors and re-run.
+   e. Invoke the **Reviewer** agent as a sub-agent to validate fixes
+   f. If Reviewer finds critical issues, fix them before proceeding
+   g. Commit the fixes: `fix: address review feedback`
+   h. Push the changes
+   i. Resolve addressed review threads using `gh` CLI:
+   ```bash
+   # Get thread IDs
+   gh api graphql -f query='{
+     repository(owner: "OWNER", name: "REPO") {
+       pullRequest(number: N) {
+         reviewThreads(first: 50) {
+           nodes { id isResolved }
+         }
+       }
+     }
+   }'
+
+   # Resolve each addressed thread
+   gh api graphql -f query='mutation {
+     resolveReviewThread(input: {threadId: "THREAD_ID"}) {
+       thread { isResolved }
+     }
+   }'
+   ```
+   j. Re-request Copilot review
+   k. Wait 2 minutes, then loop back to step 1
+
+### Phase 4: Timeout Handling
+
+If after 5 full cycles there are still unresolved comments:
+
+- Report remaining unresolved items to the user
+- Summarize what was addressed and what remains
+- Yield control
+
+### Phase 5: Completion
+
+When the PR has no actionable comments or is approved:
+
+- Report "PR review complete — ready to merge" (or "PR approved")
+- Do NOT auto-merge unless explicitly instructed
+
+---
+
+## Rules
+
+- **Never skip pre-commit checks** — every push must have clean `cargo fmt` + `cargo clippy`
+- **Never use `#[allow(...)]`** to suppress clippy warnings without user approval
+- **Always invoke the Reviewer agent** before pushing fixes — this catches issues before Copilot review does
+- **Resolve threads** after fixing — don't leave addressed comments as unresolved
+- **Don't argue with reviewers** — if a comment requests a change, make it. If you genuinely disagree, flag it for the user rather than ignoring it
+- **Extract repo owner/name** from the git remote URL or the PR context — don't hardcode
+
+## Determining Repo Owner and Name
+
+Parse from git remote:
+
+```bash
+git remote get-url origin
+```
+
+Extract owner and repo name from the URL (handles both HTTPS and SSH formats).
+
+## Status Reporting
+
+After each cycle, briefly report:
+
+- Number of comments found vs addressed
+- Any comments you couldn't address (and why)
+- Current PR status (changes requested / pending / approved)

--- a/.github/skills/rust-locator-patterns/SKILL.md
+++ b/.github/skills/rust-locator-patterns/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: "rust-locator-patterns"
+description: "PET (Python Environment Tools) Rust coding conventions: locator ordering, thread safety, platform gating, JSONRPC rules, version detection, and path/symlink handling. Reference when writing or reviewing Rust code in this repo to avoid convention violations that cause review churn."
+---
+
+# PET Rust Locator Patterns & Conventions
+
+Domain knowledge for writing correct Rust code in the Python Environment Tools (PET) repository. Following these patterns prevents the most common review feedback and CI failures.
+
+## Locator Ordering (CRITICAL)
+
+The order of locators in `create_locators()` in `crates/pet/src/locators.rs` determines identification priority. **More specific locators MUST come before generic ones.**
+
+### Priority Chain (required order):
+1. **Windows-specific:** Windows Store → Windows Registry → WinPython
+2. **Managed environments:** PyEnv → Pixi → Conda
+3. **Virtual envs (specific → generic):** Poetry → PipEnv → VirtualEnvWrapper → Venv → VirtualEnv
+4. **macOS-specific:** Homebrew → MacXCode → MacCmdLineTools → MacPythonOrg
+5. **Linux fallback:** LinuxGlobalPython (MUST BE LAST)
+
+**Why it matters:** If `Venv` runs before `Poetry`, a Poetry environment (which IS a venv) gets misidentified as a plain venv. The first locator whose `try_from()` returns `Some` wins.
+
+## Environment Identification (`try_from`)
+
+Each `try_from()` must be **precise enough to avoid false positives**:
+
+- **Poetry:** Match `{project-name}-{8-char-hash}-py{major}.{minor}` naming pattern AND verify location is in poetry cache dir
+- **Pipenv:** Look for `.project` file in centralized dir with hash-based naming
+- **Conda:** Require `conda-meta/` directory with history file
+- **Pixi:** Require `.pixi/envs/` in path structure
+- **venv:** Check for `pyvenv.cfg` file (but many env types have this — venv is a fallback)
+- **VirtualEnv:** Activation scripts WITHOUT `pyvenv.cfg` (most generic, last resort)
+
+**Red flag:** A `try_from()` that only checks `pyvenv.cfg` existence — that matches ALL venvs, not just one type.
+
+## JSONRPC Protocol Rules
+
+The server communicates via stdin/stdout. **Any stdout pollution breaks the protocol.**
+
+- **NEVER use `println!`** — it writes to stdout and corrupts JSONRPC messages
+- Use `log` crate macros: `info!()`, `trace!()`, `warn!()`, `error!()`
+- Log with elapsed time for diagnostic handlers (established pattern)
+- All tracing/logging writes to stderr via subscriber configuration
+
+## Thread Safety Patterns
+
+PET uses heavy concurrency for parallel discovery:
+
+- Shared state requires `Arc<Mutex<T>>` or `Arc<RwLock<T>>`
+- Keep lock scopes minimal — clone data out, drop lock, then process
+- Use `.expect("context")` on mutex locks, not bare `.unwrap()`
+- No nested locks (deadlock risk)
+- Consider `thread::scope` for structured concurrency
+
+## Platform-Specific Code
+
+Use `#[cfg(...)]` attributes for conditional compilation:
+
+```rust
+#[cfg(windows)]
+use pet_windows_registry::WindowsRegistry;
+
+#[cfg(unix)]
+fn resolve_path(p: &Path) -> PathBuf { std::fs::canonicalize(p).unwrap_or(p.to_path_buf()) }
+
+#[cfg(target_os = "macos")]
+use pet_homebrew::Homebrew;
+```
+
+**Do NOT use `if cfg!(windows) { ... }` for code that imports platform-specific modules** — the code inside still gets compiled on all platforms.
+
+### Platform Gotchas:
+- **Windows:** Avoid `canonicalize()` for directory junctions (breaks Scoop symlinks). Use `norm_case()` instead.
+- **macOS:** Homebrew has complex symlink chains; `resolve_symlink` before `canonicalize`
+- **Linux:** `/bin` may symlink to `/usr/bin` — handle both
+
+## Version Detection (Prefer File-Based)
+
+**Order of preference (cheapest first):**
+1. `pyvenv.cfg` — `version` or `version_info` field
+2. `conda-meta/python-*.json` — package metadata
+3. `Include/patchlevel.h` — CPython source header
+4. Parse from executable path (e.g., `python3.11`)
+5. Spawn Python `--version` — **LAST RESORT** (expensive, defeats PET's purpose)
+
+## Path & Symlink Handling
+
+- Use `pet_fs::path::resolve_symlink()` — the project's own resolver
+- For comparison: `canonicalize().unwrap_or(original)` then `norm_case()` for Windows UNC prefix handling
+- Preserve original user-facing paths; resolve only for identification
+
+## Testing Conventions
+
+- Feature-gated CI tests: `#[cfg_attr(feature = "ci", test)]` with `#[allow(dead_code)]`
+- Feature flags: `ci`, `ci-poetry-global`, `ci-jupyter-container`, `ci-homebrew-container`
+- Verification pattern: spawn Python, use `try_from()`, test symlinks, use `resolve`
+- Use `cargo test --features ci` for CI-gated tests
+
+## Serialization
+
+- All JSON-serialized structs use `#[serde(rename_all = "camelCase")]`
+- Matches the JSONRPC API conventions consumed by VS Code Python extension
+
+## Pre-Commit Requirements
+
+Always run before committing:
+```bash
+cargo fmt --all
+cargo clippy --all -- -D warnings
+```
+Never suppress clippy warnings with `#[allow(...)]` without justification.
+
+## Conda-Specific Patterns
+
+- Conda manager detection takes precedence over mamba: `get_conda_manager(path).or_else(|| get_mamba_manager(path))`
+- Managers reported separately (Conda, Mamba) but environments remain `PythonEnvironmentKind::Conda`
+- Support detection from history files and conda-meta directories

--- a/.github/skills/rust-precommit/SKILL.md
+++ b/.github/skills/rust-precommit/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: "rust-precommit"
+description: "Run the mandatory PET Rust pre-commit checks (cargo fmt + cargo clippy -D warnings) before every commit. Invoke whenever you are about to commit Rust changes, after applying review feedback, or whenever you need to verify formatting and lint cleanliness."
+---
+
+# Rust Pre-Commit Checks
+
+The PET maintainer workflow requires `cargo fmt --all` and `cargo clippy --all -- -D warnings` to pass before every commit. This skill wraps both into a single script invocation.
+
+## When to use
+
+- Before staging any Rust changes for commit.
+- After fixing review comments on a PR, before pushing.
+- Whenever the agent is asked "run pre-commit checks" or "validate the Rust code".
+
+## How to run
+
+From the workspace root:
+
+### Windows (pwsh)
+
+```powershell
+./scripts/rust-precommit.ps1
+```
+
+### macOS / Linux
+
+```bash
+./scripts/rust-precommit.sh
+```
+
+Both scripts:
+
+1. Run `cargo fmt --all` (auto-formats; fails only on unrecoverable errors).
+2. Run `cargo clippy --all -- -D warnings` (treats warnings as errors).
+3. Exit non-zero on the first failure so callers can gate commits.
+
+## Handling failures
+
+- **fmt failure:** rare; usually a syntax error preventing parsing. Fix the underlying compile error first.
+- **clippy failure:** read the diagnostic, fix the code. Do **not** add `#[allow(...)]` to suppress unless absolutely justified.
+- After any fix, re-run the script until it reports `ALL PRE-COMMIT CHECKS PASSED`.
+
+## Notes
+
+- The script must be run from the repository root (or pass the workspace path as the first arg to the `.sh` variant / `-WorkspacePath` to the `.ps1` variant).
+- Keep the script in sync with `.github/copilot-instructions.md` "Required Before Committing" section.

--- a/scripts/rust-precommit.ps1
+++ b/scripts/rust-precommit.ps1
@@ -1,0 +1,41 @@
+#!/usr/bin/env pwsh
+# Rust pre-commit checks for PET workspace.
+# Runs `cargo fmt --all` and `cargo clippy --all -- -D warnings`.
+# Exits non-zero on any failure so callers can gate commits.
+
+[CmdletBinding()]
+param(
+    [string]$WorkspacePath = (Get-Location).Path
+)
+
+$ErrorActionPreference = 'Stop'
+Set-Location -Path $WorkspacePath
+
+Write-Host '=== RUST PRE-COMMIT CHECKS ===' -ForegroundColor Cyan
+
+if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+    Write-Error 'FAIL: cargo not found in PATH'
+    exit 1
+}
+
+Write-Host ''
+Write-Host '--- Step 1: cargo fmt --all ---' -ForegroundColor Cyan
+& cargo fmt --all
+if ($LASTEXITCODE -ne 0) {
+    Write-Error 'FAIL: cargo fmt failed.'
+    exit 1
+}
+Write-Host 'PASS: Formatting complete.' -ForegroundColor Green
+
+Write-Host ''
+Write-Host '--- Step 2: cargo clippy --all -- -D warnings ---' -ForegroundColor Cyan
+& cargo clippy --all -- -D warnings
+if ($LASTEXITCODE -ne 0) {
+    Write-Error 'FAIL: clippy reported errors. Fix them, then re-run.'
+    exit 1
+}
+Write-Host 'PASS: Clippy clean.' -ForegroundColor Green
+
+Write-Host ''
+Write-Host '=== ALL PRE-COMMIT CHECKS PASSED ===' -ForegroundColor Green
+Write-Host 'Safe to commit.'

--- a/scripts/rust-precommit.sh
+++ b/scripts/rust-precommit.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Rust pre-commit checks for PET workspace.
+# Runs `cargo fmt --all` and `cargo clippy --all -- -D warnings`.
+# Exits non-zero on any failure so callers can gate commits.
+
+set -euo pipefail
+
+WORKSPACE="${1:-.}"
+cd "$WORKSPACE"
+
+echo "=== RUST PRE-COMMIT CHECKS ==="
+
+if ! command -v cargo &> /dev/null; then
+    if [ -f "$HOME/.cargo/env" ]; then
+        # shellcheck disable=SC1091
+        source "$HOME/.cargo/env"
+    else
+        echo "FAIL: cargo not found in PATH" >&2
+        exit 1
+    fi
+fi
+
+echo ""
+echo "--- Step 1: cargo fmt --all ---"
+if ! cargo fmt --all; then
+    echo "FAIL: cargo fmt failed." >&2
+    exit 1
+fi
+echo "PASS: Formatting complete."
+
+echo ""
+echo "--- Step 2: cargo clippy --all -- -D warnings ---"
+if ! cargo clippy --all -- -D warnings; then
+    echo "FAIL: clippy reported errors. Fix them, then re-run." >&2
+    exit 1
+fi
+echo "PASS: Clippy clean."
+
+echo ""
+echo "=== ALL PRE-COMMIT CHECKS PASSED ==="
+echo "Safe to commit."


### PR DESCRIPTION
Adds a self-contained pre-commit helper for the Rust workspace so the mandatory `cargo fmt --all` + `cargo clippy --all -- -D warnings` checks can be invoked with a single command (and surfaced to Copilot via a skill) without depending on the VS Code Toolbox extension.

- `scripts/rust-precommit.ps1` (Windows / pwsh) and `scripts/rust-precommit.sh` (macOS/Linux): run fmt then clippy, fail fast on the first error.
- `.github/skills/rust-precommit/SKILL.md`: instructs the agent when and how to run the script.

Verified locally: `./scripts/rust-precommit.ps1` reports `ALL PRE-COMMIT CHECKS PASSED` on `main`.