### PR TITLE
Fix Homebrew container install user

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -417,8 +417,9 @@ jobs:
           # The job container runs as root so Actions checkout/tooling can write to the
           # mounted workspace, but Homebrew's prefix is owned by linuxbrew and recent
           # homebrew/brew images have been brittle when `brew install` runs as root.
-          su - linuxbrew -c 'brew update || true'
-          su - linuxbrew -c 'brew install python@3.12 python@3.11'
+          brew_bin="$(command -v brew)"
+          su linuxbrew -c "${brew_bin} update || true"
+          su linuxbrew -c "${brew_bin} install python@3.12 python@3.11"
         shell: bash
 
       # Rust

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -414,10 +414,11 @@ jobs:
       - name: Homebrew Python
         if: startsWith( matrix.image, 'homebrew')
         run: |
-          # homebrew/brew:4.4.6 broke running `brew install` as root.
-          # As a workaround, running `brew update` and ignoring errors coming from it fixes `brew install`.
-          brew update || true
-          brew install python@3.12 python@3.11
+          # The job container runs as root so Actions checkout/tooling can write to the
+          # mounted workspace, but Homebrew's prefix is owned by linuxbrew and recent
+          # homebrew/brew images have been brittle when `brew install` runs as root.
+          su - linuxbrew -c 'brew update || true'
+          su - linuxbrew -c 'brew install python@3.12 python@3.11'
         shell: bash
 
       # Rust


### PR DESCRIPTION
## Summary

Run the Homebrew setup commands in the `homebrew/brew` container as the `linuxbrew` user instead of root, while discovering the `brew` executable from the container PATH at runtime.

The container job still runs as root so GitHub Actions checkout/tooling can write to the mounted workspace, but recent `homebrew/brew` images have been brittle when `brew install` itself runs as root. PR #466 is currently failing before Rust setup/tests with Homebrew crashing while pouring the `ca-certificates` bottle:

```text
undefined method '[]' for nil
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/bottles.rb:127:in 'Utils::Bottles.load_tab'
```

This PR keeps the existing container shape but switches the install step to:

```bash
brew_bin="$(command -v brew)"
su linuxbrew -c "${brew_bin} update || true"
su linuxbrew -c "${brew_bin} install python@3.12 python@3.11"
```

That avoids hardcoding the Linuxbrew prefix while still avoiding root-owned Homebrew install behavior.

## Validation

This is a CI-only workaround. The useful validation is the `ci-homebrew-container` Actions job on this PR.