### PR TITLE
fix: bound resolve spawn with timeout to prevent indefinite hangs (Fixes #463)

### DIFF
--- a/crates/pet-python-utils/src/env.rs
+++ b/crates/pet-python-utils/src/env.rs
@@ -1,18 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use log::{error, trace};
+use log::{error, trace, warn};
 use pet_core::{arch::Architecture, env::PythonEnv, python_environment::PythonEnvironment};
 use serde::{Deserialize, Serialize};
 use std::{
     path::{Path, PathBuf},
-    time::SystemTime,
+    process::Stdio,
+    thread,
+    time::{Duration, Instant, SystemTime},
 };
 
 use crate::{cache::create_cache, executable::new_silent_command};
 
 const PYTHON_INFO_JSON_SEPARATOR: &str = "093385e9-59f7-4a16-a604-14bf206256fe";
 const PYTHON_INFO_CMD:&str = "import json, sys; print('093385e9-59f7-4a16-a604-14bf206256fe');print(json.dumps({'version': '.'.join(str(n) for n in sys.version_info), 'sys_prefix': sys.prefix, 'executable': sys.executable, 'is64_bit': sys.maxsize > 2**32}))";
+
+/// Maximum wall-clock time to wait for a spawned Python interpreter to print
+/// its info JSON before we give up and kill it. Stale cached paths on Windows
+/// (Store stubs, vanished network shares, EDR-stalled `CreateProcess`) can
+/// otherwise block `resolve` for tens to hundreds of seconds (Fixes #463).
+const RESOLVE_SPAWN_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct InterpreterInfo {
@@ -88,13 +96,66 @@ impl ResolvedPythonEnv {
 }
 
 fn get_interpreter_details(executable: &Path) -> Option<ResolvedPythonEnv> {
+    get_interpreter_details_with_timeout(executable, RESOLVE_SPAWN_TIMEOUT)
+}
+
+fn get_interpreter_details_with_timeout(
+    executable: &Path,
+    timeout: Duration,
+) -> Option<ResolvedPythonEnv> {
     // Spawn the python exe and get the version, sys.prefix and sys.executable.
     let executable = executable.to_str()?;
     let start = SystemTime::now();
     trace!("Executing Python: {} -c {}", executable, PYTHON_INFO_CMD);
-    let result = new_silent_command(executable)
+    let mut child = match new_silent_command(executable)
         .args(["-c", PYTHON_INFO_CMD])
-        .output();
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(err) => {
+            error!(
+                "Failed to spawn Python to resolve info {:?}: {}",
+                executable, err
+            );
+            return None;
+        }
+    };
+
+    // Poll for completion up to the timeout. A stale cached path on Windows
+    // (Store stub, vanished network share, EDR-stalled `CreateProcess`) can
+    // otherwise block `wait_with_output()` for tens to hundreds of seconds.
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => break,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    warn!(
+                        "Timed out after {:?} resolving Python via spawn for {:?}; killing child.",
+                        timeout, executable
+                    );
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                thread::sleep(Duration::from_millis(25));
+            }
+            Err(err) => {
+                error!(
+                    "Failed to wait on Python interpreter spawn for {:?}: {}",
+                    executable, err
+                );
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
+
+    let result = child.wait_with_output();
     match result {
         Ok(output) => {
             let output = String::from_utf8(output.stdout).unwrap().trim().to_string();
@@ -141,5 +202,47 @@ fn get_interpreter_details(executable: &Path) -> Option<ResolvedPythonEnv> {
             );
             None
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Regression test for #463: a spawn that never exits must not block the
+    /// resolve path indefinitely. We use a shell script that sleeps far longer
+    /// than the test timeout and assert that the call returns None promptly
+    /// (well under the script's sleep duration).
+    #[test]
+    fn get_interpreter_details_times_out_on_hanging_executable() {
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "pet_resolve_timeout_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&tmp_dir).unwrap();
+        let fake_exe = tmp_dir.join("hangs");
+        std::fs::write(&fake_exe, "#!/bin/sh\nsleep 60\n").unwrap();
+        let mut perms = std::fs::metadata(&fake_exe).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_exe, perms).unwrap();
+
+        let start = Instant::now();
+        let result = get_interpreter_details_with_timeout(&fake_exe, Duration::from_millis(200));
+        let elapsed = start.elapsed();
+
+        let _ = std::fs::remove_file(&fake_exe);
+        let _ = std::fs::remove_dir(&tmp_dir);
+
+        assert!(result.is_none(), "hanging spawn must return None");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "spawn must be killed near the timeout (took {:?})",
+            elapsed
+        );
     }
 }


### PR DESCRIPTION
Fixes #463.

## Problem

`pet.resolve` p90 > 200s (p95 > 350s, p99 = 122s on Windows) for the `cache_stale` cohort tracked by the Python Environments extension. The extension's `envSelection` foreground path waits on this `resolve`, so when it hangs the user sees a 30s+ hang detected by the watchdog.

Root cause: `get_interpreter_details` in `crates/pet-python-utils/src/env.rs` calls `std::process::Command::output()` on the executable. That is a **synchronous, unbounded wait** — there is no timeout, no kill. On Windows this is the textbook way to stall on a stale cached path:

- A cached path pointing at `~/AppData/Local/Microsoft/WindowsApps/python.exe` for an uninstalled Store install — invoking the App Execution Alias stub can open the Store UI and block until dismissed.
- A cached path on a network share whose mount has gone away — `CreateProcess` blocks on SMB.
- An EDR / antivirus product stalling `CreateProcess` for tens of seconds while it scans the exe.

The per-exe cache `Mutex` is also held across this spawn, so a single hung resolve blocks every other resolve of the same path.

## Fix

Replace `Command::output()` with `spawn()` + bounded `try_wait()` polling. On timeout (15 s default) we `kill()` the child, `wait()` to reap it, and return `None`. Behavior on success is unchanged.

```rust
let mut child = new_silent_command(executable)
    .args(["-c", PYTHON_INFO_CMD])
    .stdin(Stdio::null())
    .stdout(Stdio::piped())
    .stderr(Stdio::piped())
    .spawn()?;

let deadline = Instant::now() + RESOLVE_SPAWN_TIMEOUT;
loop {
    match child.try_wait() {
        Ok(Some(_)) => break,
        Ok(None) if Instant::now() >= deadline => {
            let _ = child.kill();
            let _ = child.wait();
            return None;
        }
        Ok(None) => thread::sleep(Duration::from_millis(25)),
        Err(_) => { let _ = child.kill(); let _ = child.wait(); return None; }
    }
}
```

15 s is well above the worst observed legitimate spawn time (low single-digit seconds even on cold cache + Defender) and well below the extension's hang-detection threshold, so legitimate slow spawns still succeed while pathological hangs are bounded.

## Why not a separate worker thread + channel?

`try_wait()` polling avoids spawning an extra thread per resolve and avoids ownership gymnastics around the `Child`. The 25 ms poll interval adds at most a single poll of latency to a fast spawn (a typical spawn returns in 50–200 ms), which is negligible vs. the JSONRPC round-trip.

## Why not drop the cache `Mutex` during the spawn?

The mutex serializes concurrent resolves of the same exe so they share one spawn rather than racing. With the spawn now bounded, holding the lock for ≤15 s is acceptable; dropping it would be a larger behavior change worth doing separately.

## Test

Added a Unix regression test that writes a shell script which `sleep`s for 60 s, calls the bounded resolver with a 200 ms timeout, and asserts:
- the call returns `None`,
- elapsed time is well under the script's sleep duration (the child was actually killed).

```text
running 1 test
test env::tests::get_interpreter_details_times_out_on_hanging_executable ... ok
```

Test is gated to `#[cfg(all(test, unix))]` because constructing a hang-on-launch executable on Windows requires a different fixture; the production code path is exercised on all platforms.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --all -- -D warnings` — clean
- `cargo test -p pet-python-utils` — passes including the new regression test
- `./scripts/rust-precommit.sh` — `=== ALL PRE-COMMIT CHECKS PASSED ===`

## Expected impact

Based on the extension team's June 1 report, this should close most of the remaining ~1.57 pp bad-experience gap on insiders vs. v1.30 stable: `envSelection` hangs (dominant stage across win32 / linux / darwin, `globalScopeDeferred = deferred`) all flow through this code path via the extension's cache-stale resolve.