### PR TITLE
feat: include git commit SHA in PET `info` response for telemetry regression tracking

### DIFF
--- a/crates/pet/build.rs
+++ b/crates/pet/build.rs
@@ -8,10 +8,16 @@ fn main() {
     println!("cargo:rerun-if-env-changed=BUILD_SOURCEVERSION");
     println!("cargo:rerun-if-env-changed=GITHUB_SHA");
 
+    // Filter empties per-candidate so an explicitly-set-but-empty primary var
+    // doesn't short-circuit the fallback chain (e.g., `PET_BUILD_ID=""`).
     if let Some(build_id) = std::env::var("PET_BUILD_ID")
         .ok()
-        .or_else(|| std::env::var("BUILD_BUILDID").ok())
         .filter(|value| !value.is_empty())
+        .or_else(|| {
+            std::env::var("BUILD_BUILDID")
+                .ok()
+                .filter(|value| !value.is_empty())
+        })
     {
         println!("cargo:rustc-env=PET_BUILD_ID={build_id}");
     }
@@ -19,9 +25,17 @@ fn main() {
     // BUILD_SOURCEVERSION is set by Azure Pipelines; GITHUB_SHA by GitHub Actions.
     if let Some(commit_sha) = std::env::var("PET_COMMIT_SHA")
         .ok()
-        .or_else(|| std::env::var("BUILD_SOURCEVERSION").ok())
-        .or_else(|| std::env::var("GITHUB_SHA").ok())
         .filter(|value| !value.is_empty())
+        .or_else(|| {
+            std::env::var("BUILD_SOURCEVERSION")
+                .ok()
+                .filter(|value| !value.is_empty())
+        })
+        .or_else(|| {
+            std::env::var("GITHUB_SHA")
+                .ok()
+                .filter(|value| !value.is_empty())
+        })
     {
         println!("cargo:rustc-env=PET_COMMIT_SHA={commit_sha}");
     }

--- a/crates/pet/build.rs
+++ b/crates/pet/build.rs
@@ -4,6 +4,9 @@
 fn main() {
     println!("cargo:rerun-if-env-changed=PET_BUILD_ID");
     println!("cargo:rerun-if-env-changed=BUILD_BUILDID");
+    println!("cargo:rerun-if-env-changed=PET_COMMIT_SHA");
+    println!("cargo:rerun-if-env-changed=BUILD_SOURCEVERSION");
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
 
     if let Some(build_id) = std::env::var("PET_BUILD_ID")
         .ok()
@@ -11,6 +14,16 @@ fn main() {
         .filter(|value| !value.is_empty())
     {
         println!("cargo:rustc-env=PET_BUILD_ID={build_id}");
+    }
+
+    // BUILD_SOURCEVERSION is set by Azure Pipelines; GITHUB_SHA by GitHub Actions.
+    if let Some(commit_sha) = std::env::var("PET_COMMIT_SHA")
+        .ok()
+        .or_else(|| std::env::var("BUILD_SOURCEVERSION").ok())
+        .or_else(|| std::env::var("GITHUB_SHA").ok())
+        .filter(|value| !value.is_empty())
+    {
+        println!("cargo:rustc-env=PET_COMMIT_SHA={commit_sha}");
     }
 
     #[cfg(target_os = "windows")]

--- a/crates/pet/src/jsonrpc.rs
+++ b/crates/pet/src/jsonrpc.rs
@@ -1542,7 +1542,7 @@ mod tests {
     }
 
     #[test]
-    fn test_info_response_uses_package_version_and_optional_build_id() {
+    fn test_info_response_uses_package_version_and_optional_build_metadata() {
         let info = InfoResponse::current();
 
         assert_eq!(info.pet_version, env!("CARGO_PKG_VERSION"));
@@ -1556,6 +1556,31 @@ mod tests {
             .commit_sha
             .as_deref()
             .is_none_or(|commit_sha| !commit_sha.is_empty()));
+    }
+
+    #[test]
+    fn test_info_response_serializes_camel_case_and_omits_none() {
+        // Guards the JSON wire format (camelCase rename + skip_serializing_if)
+        // independently of whether CI env vars were set at compile time.
+        let json = serde_json::to_value(InfoResponse {
+            pet_version: "1.2.3".to_string(),
+            build_id: Some("42".to_string()),
+            commit_sha: Some("abc123".to_string()),
+        })
+        .unwrap();
+        assert_eq!(json["petVersion"], "1.2.3");
+        assert_eq!(json["buildId"], "42");
+        assert_eq!(json["commitSha"], "abc123");
+
+        let json = serde_json::to_value(InfoResponse {
+            pet_version: "1.2.3".to_string(),
+            build_id: None,
+            commit_sha: None,
+        })
+        .unwrap();
+        assert_eq!(json["petVersion"], "1.2.3");
+        assert!(json.get("buildId").is_none());
+        assert!(json.get("commitSha").is_none());
     }
 
     #[test]

--- a/crates/pet/src/jsonrpc.rs
+++ b/crates/pet/src/jsonrpc.rs
@@ -523,6 +523,8 @@ pub struct InfoResponse {
     pub pet_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
 }
 
 impl InfoResponse {
@@ -530,6 +532,9 @@ impl InfoResponse {
         Self {
             pet_version: env!("CARGO_PKG_VERSION").to_string(),
             build_id: option_env!("PET_BUILD_ID")
+                .filter(|value| !value.is_empty())
+                .map(ToString::to_string),
+            commit_sha: option_env!("PET_COMMIT_SHA")
                 .filter(|value| !value.is_empty())
                 .map(ToString::to_string),
         }
@@ -1541,10 +1546,16 @@ mod tests {
         let info = InfoResponse::current();
 
         assert_eq!(info.pet_version, env!("CARGO_PKG_VERSION"));
+        // build_id / commit_sha are populated from env vars set at compile time by CI.
+        // For local dev builds they will be None; assert non-empty only when present.
         assert!(info
             .build_id
             .as_deref()
             .is_none_or(|build_id| !build_id.is_empty()));
+        assert!(info
+            .commit_sha
+            .as_deref()
+            .is_none_or(|commit_sha| !commit_sha.is_empty()));
     }
 
     #[test]

--- a/crates/pet/tests/jsonrpc_client.rs
+++ b/crates/pet/tests/jsonrpc_client.rs
@@ -26,6 +26,7 @@ pub struct RefreshResult {
 pub struct PetInfoResponse {
     pub pet_version: String,
     pub build_id: Option<String>,
+    pub commit_sha: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]

--- a/crates/pet/tests/jsonrpc_server_test.rs
+++ b/crates/pet/tests/jsonrpc_server_test.rs
@@ -117,10 +117,16 @@ fn info_reports_pet_version_and_optional_build_id() {
     let info = client.info().expect("info request failed");
 
     assert_eq!(info.pet_version, env!("CARGO_PKG_VERSION"));
+    // build_id / commit_sha are populated from env vars set at compile time by CI.
+    // For local dev builds they will be None; assert non-empty only when present.
     assert!(info
         .build_id
         .as_deref()
         .is_none_or(|build_id| !build_id.is_empty()));
+    assert!(info
+        .commit_sha
+        .as_deref()
+        .is_none_or(|commit_sha| !commit_sha.is_empty()));
 }
 
 #[test]

--- a/crates/pet/tests/jsonrpc_server_test.rs
+++ b/crates/pet/tests/jsonrpc_server_test.rs
@@ -111,7 +111,7 @@ fn assert_single_environment(
 }
 
 #[test]
-fn info_reports_pet_version_and_optional_build_id() {
+fn info_reports_pet_version_and_optional_build_metadata() {
     let client = PetJsonRpcClient::spawn().expect("failed to spawn PET server");
 
     let info = client.info().expect("info request failed");

--- a/docs/JSONRPC.md
+++ b/docs/JSONRPC.md
@@ -35,8 +35,15 @@ interface InfoResponse {
   petVersion: string;
   /**
    * Build identifier baked into the binary when built by CI.
+   * Sourced from `PET_BUILD_ID` or Azure Pipelines `BUILD_BUILDID`.
    */
   buildId?: string;
+  /**
+   * Source git commit SHA baked into the binary when built by CI.
+   * Sourced from `PET_COMMIT_SHA`, Azure Pipelines `BUILD_SOURCEVERSION`,
+   * or GitHub Actions `GITHUB_SHA`. Absent for local dev builds.
+   */
+  commitSha?: string;
 }
 ```
 


### PR DESCRIPTION
## Background

PET (Python Environment Tools) is a Rust-based JSONRPC server used by the VS Code Python extension to discover Python environments. PET does not send its own telemetry — instead, it returns metadata to the calling extension (vscode-python-environments), which forwards it via telemetry.

To help catch regressions, we need a way to know exactly which PET build a user is running by querying telemetry. [PR #470](https://github.com/microsoft/python-environment-tools/pull/470) added a JSONRPC `info` request that returns PET's version and an optional CI build ID. However, the build number alone isn't enough to pinpoint the exact source code — we also need the git commit hash.

This PR extends the `info` response to include the **git commit SHA** baked into the binary at build time. On the extension side, the companion PR ([vscode-python-environments#1548](https://github.com/microsoft/vscode-python-environments/pull/1548)) passes this information along to telemetry, so we can correlate user-reported issues or regressions back to the specific PET commit.

## What Changed

### 1. Build script (`crates/pet/build.rs`)

- Added support for three new environment variables that CI systems set automatically:
  - `PET_COMMIT_SHA` — explicit override (highest priority)
  - `BUILD_SOURCEVERSION` — set by Azure Pipelines
  - `GITHUB_SHA` — set by GitHub Actions
- When any of these is present and non-empty, the value is embedded into the binary as a compile-time constant via `cargo:rustc-env=PET_COMMIT_SHA=...`.

### 2. JSONRPC response (`crates/pet/src/jsonrpc.rs`)

- Added a new optional `commit_sha` field to the `InfoResponse` struct.
- `InfoResponse::current()` populates it from the compile-time `PET_COMMIT_SHA` env var (same pattern used for `build_id`).
- For local dev builds where no CI env var is set, the field is `None` and omitted from the JSON response.

### 3. JSONRPC documentation (`docs/JSONRPC.md`)

- Updated the `InfoResponse` TypeScript interface to document the new `commitSha?: string` field, including where the value is sourced from.

### 4. Tests (`crates/pet/src/jsonrpc.rs`, `crates/pet/tests/jsonrpc_server_test.rs`, `crates/pet/tests/jsonrpc_client.rs`)

- Added `commit_sha` field to the test client's `PetInfoResponse` struct.
- Added assertions that `commit_sha`, when present, is non-empty (mirrors existing `build_id` assertion pattern).
- Added clarifying comments explaining that both `build_id` and `commit_sha` are `None` in local dev builds and only populated in CI.

## How It Works

```
CI build (Azure Pipelines / GitHub Actions)
  ↓ sets BUILD_SOURCEVERSION or GITHUB_SHA
build.rs captures it → bakes into binary as PET_COMMIT_SHA
  ↓
JSONRPC `info` request → returns { petVersion, buildId, commitSha }
  ↓
vscode-python-environments extension → includes commitSha in telemetry
  ↓
Team queries telemetry → correlates regressions to exact PET commit
```

## Related PRs

- [PET PR #470](https://github.com/microsoft/python-environment-tools/pull/470) — Added the `info` JSONRPC request with version and build ID (merged)
- [vscode-python-environments PR #1548](https://github.com/microsoft/vscode-python-environments/pull/1548) — Extension-side: passes PET version/build/commit info to telemetry
