### PR TITLE
fix: add resource block var

### DIFF
--- a/azure-pipelines/playground.yml
+++ b/azure-pipelines/playground.yml
@@ -10,6 +10,10 @@ resources:
       ref: main
       endpoint: Monaco
 
+variables:
+  # Required to enable Windows resource block in crates/pet/build.rs
+  CARGO_BIN_NAME: pet
+
 extends:
   template: azure-pipelines/rust-package/pipeline.yml@templates
   parameters:

--- a/azure-pipelines/pre-release.yml
+++ b/azure-pipelines/pre-release.yml
@@ -20,6 +20,10 @@ resources:
       ref: main
       endpoint: Monaco
 
+variables:
+  # Required to enable Windows resource block in crates/pet/build.rs
+  CARGO_BIN_NAME: pet
+
 extends:
   template: azure-pipelines/rust-package/pipeline.yml@templates
   parameters:

--- a/azure-pipelines/stable.yml
+++ b/azure-pipelines/stable.yml
@@ -10,6 +10,10 @@ resources:
       ref: main
       endpoint: Monaco
 
+variables:
+  # Required to enable Windows resource block in crates/pet/build.rs
+  CARGO_BIN_NAME: pet
+
 extends:
   template: azure-pipelines/rust-package/pipeline.yml@templates
   parameters:


### PR DESCRIPTION
This PR allows our pipelines to build the full Windows binary with custom product name info once again.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=447930&view=results