### PR TITLE
feat: improve recursive environment glob diagnostics (Fixes #427)

### DIFF
--- a/crates/pet-fs/src/glob.rs
+++ b/crates/pet-fs/src/glob.rs
@@ -21,7 +21,7 @@ pub fn is_glob_pattern(path: &str) -> bool {
 
 /// Returns true when a glob can traverse an unbounded number of path components.
 pub fn is_recursive_glob_pattern(path: &str) -> bool {
-    path.contains("**")
+    path.split(['/', '\']).any(|segment| segment == "**")
 }
 /// Checks if a string contains a valid brace expansion pattern `{a,b}`.
 /// Requires an opening `{`, at least one `,`, and a closing `}`.
@@ -212,6 +212,8 @@ mod tests {
         assert!(is_recursive_glob_pattern("/home/user/**/venv"));
         assert!(!is_recursive_glob_pattern(".venv"));
         assert!(!is_recursive_glob_pattern("*/.venv"));
+        assert!(!is_recursive_glob_pattern("foo**bar/.venv"));
+        assert!(is_recursive_glob_pattern("C:\\workspace\\**\\.venv"));
     }
     #[test]
     fn test_is_glob_pattern_with_question_mark() {

--- a/crates/pet-fs/src/glob.rs
+++ b/crates/pet-fs/src/glob.rs
@@ -21,8 +21,9 @@ pub fn is_glob_pattern(path: &str) -> bool {
 
 /// Returns true when a glob can traverse an unbounded number of path components.
 pub fn is_recursive_glob_pattern(path: &str) -> bool {
-    path.split(['/', '\']).any(|segment| segment == "**")
+    path.split(['/', '\\']).any(|segment| segment == "**")
 }
+
 /// Checks if a string contains a valid brace expansion pattern `{a,b}`.
 /// Requires an opening `{`, at least one `,`, and a closing `}`.
 fn has_brace_pattern(path: &str) -> bool {

--- a/crates/pet-fs/src/glob.rs
+++ b/crates/pet-fs/src/glob.rs
@@ -21,7 +21,9 @@ pub fn is_glob_pattern(path: &str) -> bool {
 
 /// Returns true when a glob can traverse an unbounded number of path components.
 pub fn is_recursive_glob_pattern(path: &str) -> bool {
-    path.split(['/', '\\']).any(|segment| segment == "**")
+    expand_braces(path)
+        .iter()
+        .any(|pattern| pattern.split(['/', '\\']).any(|segment| segment == "**"))
 }
 
 /// Checks if a string contains a valid brace expansion pattern `{a,b}`.
@@ -215,6 +217,7 @@ mod tests {
         assert!(!is_recursive_glob_pattern("*/.venv"));
         assert!(!is_recursive_glob_pattern("foo**bar/.venv"));
         assert!(is_recursive_glob_pattern("C:\\workspace\\**\\.venv"));
+        assert!(is_recursive_glob_pattern("{foo,**}/.venv"));
     }
     #[test]
     fn test_is_glob_pattern_with_question_mark() {

--- a/crates/pet-fs/src/glob.rs
+++ b/crates/pet-fs/src/glob.rs
@@ -19,6 +19,10 @@ pub fn is_glob_pattern(path: &str) -> bool {
     path.contains(GLOB_METACHARACTERS) || has_brace_pattern(path)
 }
 
+/// Returns true when a glob can traverse an unbounded number of path components.
+pub fn is_recursive_glob_pattern(path: &str) -> bool {
+    path.contains("**")
+}
 /// Checks if a string contains a valid brace expansion pattern `{a,b}`.
 /// Requires an opening `{`, at least one `,`, and a closing `}`.
 fn has_brace_pattern(path: &str) -> bool {
@@ -202,6 +206,13 @@ mod tests {
         assert!(is_glob_pattern("*.txt"));
     }
 
+    #[test]
+    fn test_is_recursive_glob_pattern() {
+        assert!(is_recursive_glob_pattern("**/.venv"));
+        assert!(is_recursive_glob_pattern("/home/user/**/venv"));
+        assert!(!is_recursive_glob_pattern(".venv"));
+        assert!(!is_recursive_glob_pattern("*/.venv"));
+    }
     #[test]
     fn test_is_glob_pattern_with_question_mark() {
         assert!(is_glob_pattern("/home/user/file?.txt"));

--- a/crates/pet/src/jsonrpc.rs
+++ b/crates/pet/src/jsonrpc.rs
@@ -21,7 +21,7 @@ use pet_core::{
     Configuration, Locator, RefreshStatePersistence, RefreshStateSyncScope,
 };
 use pet_env_var_path::get_search_paths_from_env_variables;
-use pet_fs::glob::expand_glob_patterns;
+use pet_fs::glob::{expand_glob_pattern, expand_glob_patterns, is_recursive_glob_pattern};
 use pet_fs::path::norm_case;
 use pet_jsonrpc::{
     send_error, send_reply,
@@ -566,6 +566,43 @@ pub struct ConfigureOptions {
 /// The client has a 30-second timeout for configure requests.
 const GLOB_EXPANSION_WARN_THRESHOLD: Duration = Duration::from_secs(5);
 
+fn expand_configure_directory_patterns(kind: &str, patterns: Vec<PathBuf>) -> Vec<PathBuf> {
+    patterns
+        .into_iter()
+        .flat_map(|pattern| {
+            let start = Instant::now();
+            let expanded = expand_glob_pattern(&pattern.to_string_lossy());
+            let elapsed = start.elapsed();
+            trace!(
+                "Expanded {} pattern '{}' in {:?}",
+                kind,
+                pattern.display(),
+                elapsed
+            );
+            if elapsed >= GLOB_EXPANSION_WARN_THRESHOLD {
+                warn!(
+                    "Expanding {} pattern '{}' took {:?}, this may cause client timeouts",
+                    kind,
+                    pattern.display(),
+                    elapsed
+                );
+            }
+            expanded
+        })
+        .filter(|path| path.is_dir())
+        .collect()
+}
+
+fn warn_for_recursive_environment_patterns(patterns: &[PathBuf]) {
+    for pattern in patterns {
+        if is_recursive_glob_pattern(&pattern.to_string_lossy()) {
+            warn!(
+                "Recursive environmentDirectories pattern '{}' can make configure slow; prefer bounded patterns such as '.venv' or '*/.venv'",
+                pattern.display()
+            );
+        }
+    }
+}
 pub fn handle_configure(context: Arc<Context>, id: u32, params: Value) {
     match serde_json::from_value::<ConfigureOptions>(params.clone()) {
         Ok(mut configure_options) => {
@@ -574,38 +611,28 @@ pub fn handle_configure(context: Arc<Context>, id: u32, params: Value) {
             thread::spawn(move || {
                 let now = Instant::now();
 
+                // Warn before any expansion so a slow workspace pattern cannot delay
+                // the actionable environmentDirectories diagnostic.
+                if let Some(patterns) = configure_options.environment_directories.as_deref() {
+                    warn_for_recursive_environment_patterns(patterns);
+                }
+
                 // Expand glob patterns before acquiring the write lock so we
                 // don't block readers/writers while traversing the filesystem.
                 let workspace_directories =
-                    configure_options.workspace_directories.take().map(|dirs| {
-                        let start = Instant::now();
-                        let result: Vec<PathBuf> = expand_glob_patterns(&dirs)
-                            .into_iter()
-                            .filter(|p| p.is_dir())
-                            .collect();
-                        trace!(
-                            "Expanded workspace directory patterns ({:?}) in {:?}",
-                            dirs,
-                            start.elapsed()
-                        );
-                        result
-                    });
+                    configure_options
+                        .workspace_directories
+                        .take()
+                        .map(|patterns| {
+                            expand_configure_directory_patterns("workspaceDirectories", patterns)
+                        });
                 let environment_directories =
                     configure_options
                         .environment_directories
                         .take()
-                        .map(|dirs| {
-                            let start = Instant::now();
-                            let result: Vec<PathBuf> = expand_glob_patterns(&dirs)
-                                .into_iter()
-                                .filter(|p| p.is_dir())
-                                .collect();
-                            trace!(
-                                "Expanded environment directory patterns ({:?}) in {:?}",
-                                dirs,
-                                start.elapsed()
-                            );
-                            result
+                        .map(|patterns| {
+                            warn_for_recursive_environment_patterns(&patterns);
+                            expand_configure_directory_patterns("environmentDirectories", patterns)
                         });
                 let glob_elapsed = now.elapsed();
                 trace!("Glob expansion completed in {:?}", glob_elapsed);

--- a/crates/pet/src/jsonrpc.rs
+++ b/crates/pet/src/jsonrpc.rs
@@ -602,7 +602,7 @@ fn recursive_environment_patterns(patterns: &[PathBuf]) -> impl Iterator<Item = 
 fn warn_for_recursive_environment_patterns(patterns: &[PathBuf]) {
     for pattern in recursive_environment_patterns(patterns) {
         warn!(
-            "Recursive environmentDirectories pattern '{}' can make configure slow; prefer non-recursive container-directory patterns such as 'envs' or '*/envs'",
+            "Recursive environmentDirectories pattern '{}' can make configure slow; prefer non-recursive container-directory patterns such as '<root>/envs' or '<root>/*/envs'",
             pattern.display()
         );
     }

--- a/crates/pet/src/jsonrpc.rs
+++ b/crates/pet/src/jsonrpc.rs
@@ -602,7 +602,7 @@ fn recursive_environment_patterns(patterns: &[PathBuf]) -> impl Iterator<Item = 
 fn warn_for_recursive_environment_patterns(patterns: &[PathBuf]) {
     for pattern in recursive_environment_patterns(patterns) {
         warn!(
-            "Recursive environmentDirectories pattern '{}' can make configure slow; prefer bounded container-directory patterns such as '/home/user/envs' or '/home/user/*/envs'",
+            "Recursive environmentDirectories pattern '{}' can make configure slow; prefer non-recursive container-directory patterns such as 'envs' or '*/envs'",
             pattern.display()
         );
     }

--- a/crates/pet/src/jsonrpc.rs
+++ b/crates/pet/src/jsonrpc.rs
@@ -593,14 +593,18 @@ fn expand_configure_directory_patterns(kind: &str, patterns: Vec<PathBuf>) -> Ve
         .collect()
 }
 
+fn recursive_environment_patterns(patterns: &[PathBuf]) -> impl Iterator<Item = &PathBuf> {
+    patterns
+        .iter()
+        .filter(|pattern| is_recursive_glob_pattern(&pattern.to_string_lossy()))
+}
+
 fn warn_for_recursive_environment_patterns(patterns: &[PathBuf]) {
-    for pattern in patterns {
-        if is_recursive_glob_pattern(&pattern.to_string_lossy()) {
-            warn!(
-                "Recursive environmentDirectories pattern '{}' can make configure slow; prefer bounded patterns such as '.venv' or '*/.venv'",
-                pattern.display()
-            );
-        }
+    for pattern in recursive_environment_patterns(patterns) {
+        warn!(
+            "Recursive environmentDirectories pattern '{}' can make configure slow; prefer bounded patterns such as '.venv' or '*/.venv'",
+            pattern.display()
+        );
     }
 }
 pub fn handle_configure(context: Arc<Context>, id: u32, params: Value) {
@@ -631,7 +635,6 @@ pub fn handle_configure(context: Arc<Context>, id: u32, params: Value) {
                         .environment_directories
                         .take()
                         .map(|patterns| {
-                            warn_for_recursive_environment_patterns(&patterns);
                             expand_configure_directory_patterns("environmentDirectories", patterns)
                         });
                 let glob_elapsed = now.elapsed();
@@ -1434,6 +1437,42 @@ mod tests {
     use std::sync::{mpsc, Barrier, Mutex};
     use std::thread;
 
+    #[test]
+    fn recursive_environment_pattern_filter_only_returns_recursive_globs() {
+        let patterns = vec![
+            PathBuf::from(".venv"),
+            PathBuf::from("*/.venv"),
+            PathBuf::from("**/.venv"),
+            PathBuf::from("/workspace/**/venv"),
+        ];
+
+        assert_eq!(
+            recursive_environment_patterns(&patterns)
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![
+                PathBuf::from("**/.venv"),
+                PathBuf::from("/workspace/**/venv")
+            ]
+        );
+    }
+
+    #[test]
+    fn configure_pattern_expansion_filters_non_directories() {
+        let temp = tempfile::tempdir().unwrap();
+        let directory = temp.path().join("env");
+        let file = temp.path().join("python.exe");
+        std::fs::create_dir(&directory).unwrap();
+        std::fs::write(&file, "").unwrap();
+
+        assert_eq!(
+            expand_configure_directory_patterns(
+                "environmentDirectories",
+                vec![temp.path().join("*")],
+            ),
+            vec![directory]
+        );
+    }
     #[derive(Default)]
     struct RecordingReporter {
         environments: Mutex<Vec<PythonEnvironment>>,

--- a/crates/pet/src/jsonrpc.rs
+++ b/crates/pet/src/jsonrpc.rs
@@ -602,7 +602,7 @@ fn recursive_environment_patterns(patterns: &[PathBuf]) -> impl Iterator<Item = 
 fn warn_for_recursive_environment_patterns(patterns: &[PathBuf]) {
     for pattern in recursive_environment_patterns(patterns) {
         warn!(
-            "Recursive environmentDirectories pattern '{}' can make configure slow; prefer bounded patterns such as '.venv' or '*/.venv'",
+            "Recursive environmentDirectories pattern '{}' can make configure slow; prefer bounded container-directory patterns such as '/home/user/envs' or '/home/user/*/envs'",
             pattern.display()
         );
     }

--- a/docs/JSONRPC.md
+++ b/docs/JSONRPC.md
@@ -83,8 +83,8 @@ interface ConfigureParams {
    *
    * Useful for VS Code so users can configure where they store virtual environments.
    *
-   * Values identify directories that contain environments. Glob patterns are supported (e.g., `envs`, `*/envs`).
-   * Avoid recursive patterns such as `**/envs`: they can traverse large directory trees,
+   * Values identify directories that contain environments. Glob patterns are supported (e.g., `<root>/envs`, `<root>/*/envs`).
+   * Avoid recursive patterns such as `<root>/**/envs`: they can traverse large directory trees,
    * delay configure responses, and trigger client timeouts.
    */
   environmentDirectories?: string[];

--- a/docs/JSONRPC.md
+++ b/docs/JSONRPC.md
@@ -83,8 +83,8 @@ interface ConfigureParams {
    *
    * Useful for VS Code so users can configure where they store virtual environments.
    *
-   * Values identify directories that contain environments. Glob patterns are supported (e.g., `/home/user/envs`, `/home/user/*/envs`).
-   * Avoid recursive patterns such as `/home/user/**/envs`: they can traverse large directory trees,
+   * Values identify directories that contain environments. Glob patterns are supported (e.g., `envs`, `*/envs`).
+   * Avoid recursive patterns such as `**/envs`: they can traverse large directory trees,
    * delay configure responses, and trigger client timeouts.
    */
   environmentDirectories?: string[];

--- a/docs/JSONRPC.md
+++ b/docs/JSONRPC.md
@@ -83,7 +83,9 @@ interface ConfigureParams {
    *
    * Useful for VS Code so users can configure where they store virtual environments.
    *
-   * Glob patterns are supported (e.g., "/home/user/envs/*", "/home/user/*/venv").
+   * Bounded glob patterns are supported (e.g., ".venv", "*/.venv", "/home/user/envs/*").
+   * Avoid recursive workspace-wide patterns such as "**/.venv": they can traverse large directory trees,
+   * delay configure responses, and trigger client timeouts.
    */
   environmentDirectories?: string[];
   /**

--- a/docs/JSONRPC.md
+++ b/docs/JSONRPC.md
@@ -74,7 +74,7 @@ interface ConfigureParams {
    * If not provided, then environments such as poetry, pipenv, and the like will not be reported.
    * This is because poetry, pipenv, and the like are project-specific environments.
    *
-   * Bounded glob patterns are supported (e.g., `/home/user/projects/*`).
+   * Glob patterns are supported (e.g., `/home/user/projects/*`). Avoid recursive `**` patterns when a single-level pattern is sufficient.
    */
   workspaceDirectories?: string[];
   /**
@@ -83,7 +83,7 @@ interface ConfigureParams {
    *
    * Useful for VS Code so users can configure where they store virtual environments.
    *
-   * Values identify directories that contain environments. Bounded patterns are supported (e.g., `/home/user/envs`, `/home/user/*/envs`).
+   * Values identify directories that contain environments. Glob patterns are supported (e.g., `/home/user/envs`, `/home/user/*/envs`).
    * Avoid recursive patterns such as `/home/user/**/envs`: they can traverse large directory trees,
    * delay configure responses, and trigger client timeouts.
    */

--- a/docs/JSONRPC.md
+++ b/docs/JSONRPC.md
@@ -72,9 +72,9 @@ interface ConfigureParams {
    * E.g. `workspace folders` in vscode.
    *
    * If not provided, then environments such as poetry, pipenv, and the like will not be reported.
-   * This is because poetry, pipenv, and the like are project specific enviornents.
+   * This is because poetry, pipenv, and the like are project-specific environments.
    *
-   * Glob patterns are supported (e.g., "/home/user/projects/*", "**/.venv").
+   * Bounded glob patterns are supported (e.g., `/home/user/projects/*`).
    */
   workspaceDirectories?: string[];
   /**
@@ -83,8 +83,8 @@ interface ConfigureParams {
    *
    * Useful for VS Code so users can configure where they store virtual environments.
    *
-   * Bounded glob patterns are supported (e.g., ".venv", "*/.venv", "/home/user/envs/*").
-   * Avoid recursive workspace-wide patterns such as "**/.venv": they can traverse large directory trees,
+   * Values identify directories that contain environments. Bounded patterns are supported (e.g., `/home/user/envs`, `/home/user/*/envs`).
+   * Avoid recursive patterns such as `/home/user/**/envs`: they can traverse large directory trees,
    * delay configure responses, and trigger client timeouts.
    */
   environmentDirectories?: string[];


### PR DESCRIPTION
## Summary

- warn immediately when `environmentDirectories` contains recursive `**` path segments
- report exact pattern names and elapsed time for slow configure glob expansions
- recommend non-recursive container-directory patterns in the JSON-RPC documentation
- support recursive globstar detection through brace expansion without flagging `foo**bar`
- add direct coverage for classification and directory-only expansion

## Validation

- `cargo test -p pet-fs`
- `cargo test -p pet configure`
- `.\scripts\rust-precommit.ps1`

Fixes #427
